### PR TITLE
Centralize server environment configuration

### DIFF
--- a/src/core/systems/ServerLiveKit.js
+++ b/src/core/systems/ServerLiveKit.js
@@ -2,6 +2,7 @@ import { AccessToken, TrackSource } from 'livekit-server-sdk'
 
 import { System } from './System'
 import { uuid } from '../utils'
+import { getServerConfig } from '../../server/config.js'
 
 const levels = ['disabled', 'spatial', 'global']
 const levelPriorities = {
@@ -10,13 +11,15 @@ const levelPriorities = {
   global: 3,
 }
 
+const { livekit: livekitConfig } = getServerConfig()
+
 export class ServerLiveKit extends System {
   constructor(world) {
     super(world)
     this.roomId = uuid()
-    this.wsUrl = process.env.LIVEKIT_WS_URL
-    this.apiKey = process.env.LIVEKIT_API_KEY
-    this.apiSecret = process.env.LIVEKIT_API_SECRET
+    this.wsUrl = livekitConfig.wsUrl
+    this.apiKey = livekitConfig.apiKey
+    this.apiSecret = livekitConfig.apiSecret
     this.enabled = this.wsUrl && this.apiKey && this.apiSecret
     this.modifiers = {} // [playerId] => Set({ level })
     this.levels = {} // [playerId] => level (disabled, spatial, global)

--- a/src/core/utils-server.js
+++ b/src/core/utils-server.js
@@ -1,5 +1,6 @@
 import crypto from 'crypto'
 import jwt from 'jsonwebtoken'
+import { getServerConfig } from '../server/config.js'
 
 /**
  *
@@ -20,7 +21,9 @@ export async function hashFile(file) {
  * JSON Web Tokens
  */
 
-const jwtSecret = process.env.JWT_SECRET
+const {
+  auth: { jwtSecret },
+} = getServerConfig()
 
 export function createJWT(data) {
   return new Promise((resolve, reject) => {

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,0 +1,187 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const serverDir = globalThis.__dirname ?? path.dirname(fileURLToPath(import.meta.url))
+const defaultRootDir = path.resolve(serverDir, '..')
+
+function readEnv(key, { required = false, defaultValue, allowEmpty = false } = {}) {
+  const rawValue = process.env[key]
+  if (rawValue === undefined || rawValue === null) {
+    if (defaultValue !== undefined) {
+      return defaultValue
+    }
+    if (required) {
+      throw new Error(`Environment variable ${key} is required`)
+    }
+    return undefined
+  }
+
+  const value = String(rawValue).trim()
+  if (!allowEmpty && value.length === 0) {
+    if (defaultValue !== undefined) {
+      return defaultValue
+    }
+    if (required) {
+      throw new Error(`Environment variable ${key} cannot be empty`)
+    }
+    return undefined
+  }
+
+  return value
+}
+
+function ensureRelativePath(value, key) {
+  if (path.isAbsolute(value)) {
+    throw new Error(`${key} must be a relative path inside the repository`)
+  }
+
+  const normalised = path.normalize(value)
+  if (normalised.startsWith('..')) {
+    throw new Error(`${key} must not traverse outside of the repository`)
+  }
+
+  return normalised
+}
+
+function parseInteger(value, key, { min, max, allowZero = true } = {}) {
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${key} must be a valid integer`)
+  }
+
+  if (!allowZero && parsed === 0) {
+    throw new Error(`${key} cannot be zero`)
+  }
+
+  if (min !== undefined && parsed < min) {
+    throw new Error(`${key} must be >= ${min}`)
+  }
+
+  if (max !== undefined && parsed > max) {
+    throw new Error(`${key} must be <= ${max}`)
+  }
+
+  return parsed
+}
+
+function normaliseUrl(value, key, { protocolWhitelist } = {}) {
+  const trimmed = value.trim()
+  try {
+    const url = new URL(trimmed)
+    if (protocolWhitelist && !protocolWhitelist.includes(url.protocol)) {
+      throw new Error(`${key} must use one of the following protocols: ${protocolWhitelist.join(', ')}`)
+    }
+    return url.toString().replace(/\/$/, '')
+  } catch (err) {
+    if (trimmed.startsWith('/')) {
+      return trimmed.replace(/\/$/, '')
+    }
+    throw new Error(`${key} must be a valid absolute URL or start with '/'`)
+  }
+}
+
+function buildPublicEnv(overrides) {
+  const publicEnvEntries = Object.entries(process.env)
+    .filter(([key]) => key.startsWith('PUBLIC_'))
+    .map(([key, value]) => [key, value === undefined || value === null ? '' : String(value)])
+
+  const merged = { ...Object.fromEntries(publicEnvEntries), ...overrides }
+  for (const key of Object.keys(merged)) {
+    merged[key] = merged[key] ?? ''
+    merged[key] = String(merged[key])
+  }
+  return Object.freeze(merged)
+}
+
+function buildServerConfig(options = {}) {
+  const rootDir = options.rootDir ? path.resolve(options.rootDir) : defaultRootDir
+
+  const worldName = ensureRelativePath(readEnv('WORLD', { required: true }), 'WORLD')
+  const worldDir = path.join(rootDir, worldName)
+  const assetsDir = path.join(worldDir, 'assets')
+  const collectionsDir = path.join(worldDir, 'collections')
+
+  const port = parseInteger(readEnv('PORT', { defaultValue: '3000' }), 'PORT', {
+    min: 1,
+    max: 65535,
+  })
+
+  const saveInterval = parseInteger(readEnv('SAVE_INTERVAL', { defaultValue: '60' }), 'SAVE_INTERVAL', {
+    min: 0,
+  })
+
+  const jwtSecret = readEnv('JWT_SECRET', { required: true })
+
+  const publicAssetsUrl = normaliseUrl(
+    readEnv('PUBLIC_ASSETS_URL', { defaultValue: `http://localhost:${port}/assets` }),
+    'PUBLIC_ASSETS_URL'
+  )
+  const publicApiUrl = normaliseUrl(
+    readEnv('PUBLIC_API_URL', { defaultValue: `http://localhost:${port}/api` }),
+    'PUBLIC_API_URL'
+  )
+  const publicWsUrl = normaliseUrl(
+    readEnv('PUBLIC_WS_URL', { defaultValue: `ws://localhost:${port}/ws` }),
+    'PUBLIC_WS_URL',
+    { protocolWhitelist: ['ws:', 'wss:'] }
+  )
+  const publicMaxUploadSize = parseInteger(
+    readEnv('PUBLIC_MAX_UPLOAD_SIZE', { defaultValue: '12' }),
+    'PUBLIC_MAX_UPLOAD_SIZE',
+    { min: 1 }
+  )
+
+  const adminCode = readEnv('ADMIN_CODE', { allowEmpty: true })
+  const hasAdminCode = !!adminCode && adminCode.length > 0
+
+  const commitHash = readEnv('COMMIT_HASH', { allowEmpty: true }) || null
+
+  const livekit = {
+    wsUrl: readEnv('LIVEKIT_WS_URL', { allowEmpty: true }) || null,
+    apiKey: readEnv('LIVEKIT_API_KEY', { allowEmpty: true }) || null,
+    apiSecret: readEnv('LIVEKIT_API_SECRET', { allowEmpty: true }) || null,
+  }
+
+  const publicEnv = buildPublicEnv({
+    PUBLIC_ASSETS_URL: publicAssetsUrl,
+    PUBLIC_API_URL: publicApiUrl,
+    PUBLIC_WS_URL: publicWsUrl,
+    PUBLIC_MAX_UPLOAD_SIZE: String(publicMaxUploadSize),
+  })
+
+  return Object.freeze({
+    rootDir,
+    world: Object.freeze({
+      name: worldName,
+      dir: worldDir,
+      assetsDir,
+      collectionsDir,
+    }),
+    server: Object.freeze({
+      port,
+      saveInterval,
+    }),
+    auth: Object.freeze({
+      jwtSecret,
+      adminCode: adminCode || null,
+      hasAdminCode,
+    }),
+    public: Object.freeze({
+      assetsUrl: publicAssetsUrl,
+      apiUrl: publicApiUrl,
+      wsUrl: publicWsUrl,
+      maxUploadSize: publicMaxUploadSize,
+      env: publicEnv,
+    }),
+    livekit: Object.freeze(livekit),
+    commitHash,
+  })
+}
+
+const serverConfig = buildServerConfig()
+
+export function getServerConfig() {
+  return serverConfig
+}
+
+export { serverConfig }


### PR DESCRIPTION
## Summary
- add a shared server configuration module that validates required environment variables and computes derived paths
- update the server entrypoint to use the sanitized configuration for world paths, public env exposure, and status reporting
- refactor server subsystems to consume the centralized configuration for JWT secrets, admin settings, LiveKit credentials, and public URLs

## Testing
- npm run lint *(fails: existing lint violations in untouched client and core files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0291cad38832db0485cc2858ffe6e