### PR TITLE
Improve automation agent ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,44 @@ npm run dev
 
 For containerized deployment, check [DOCKER.md](DOCKER.md) for detailed instructions.
 
+## 🤖 Automation Agent
+
+Hyperfy ships with a headless agent (`agent.mjs`) that can connect to a world, simulate
+basic avatar movement, and send chat messages. This is useful for smoke testing a new
+deployment, building automated demos, or populating a world with scripted behaviour.
+
+### Running the agent
+
+```bash
+node agent.mjs --ws-url ws://localhost:3000/ws --name "Bot"
+```
+
+Use CLI flags or environment variables to tailor the behaviour:
+
+| Capability | CLI flags | Environment variables |
+| --- | --- | --- |
+| Target world | `--ws-url`, `--name`, `--avatar` | `HYPERFY_AGENT_WS_URL`, `HYPERFY_AGENT_NAME`, `HYPERFY_AGENT_AVATAR` |
+| Movement | `--move-mode`, `--no-move`,<br>`--keys`, `--interval`, `--press-probability`, `--max-active` | `HYPERFY_AGENT_MOVE_MODE`, `HYPERFY_AGENT_MOVE_ENABLED`,<br>`HYPERFY_AGENT_WANDER_KEYS`, `HYPERFY_AGENT_WANDER_INTERVAL_MS`, `HYPERFY_AGENT_WANDER_PRESS_PROBABILITY`, `HYPERFY_AGENT_WANDER_MAX_ACTIVE` |
+| Chat | `--no-chat`, `--chat-message`,<br>`--chat-delay`, `--chat-repeat` | `HYPERFY_AGENT_CHAT_ENABLED`, `HYPERFY_AGENT_CHAT_MESSAGE`,<br>`HYPERFY_AGENT_CHAT_DELAY_MS`, `HYPERFY_AGENT_CHAT_REPEAT_MS` |
+| Resilience | `--auto-reconnect`, `--reconnect-delay` | `HYPERFY_AGENT_AUTO_RECONNECT`, `HYPERFY_AGENT_RECONNECT_DELAY_MS` |
+| Logging | `--silent`, `--verbose` | `HYPERFY_AGENT_VERBOSE` |
+
+All timing arguments accept milliseconds. The default movement mode is `wander`, which
+randomly toggles the configured control keys. Set `--move-mode idle` or `--no-move` to
+disable locomotion while keeping chat automation enabled.
+
+Example: keep a lightweight greeter active in a production lobby:
+
+```bash
+HYPERFY_AGENT_WS_URL=wss://my-world.example/ws \
+node agent.mjs \
+  --name "Lobby Guide" \
+  --chat-message "Welcome! Let me know if you need help." \
+  --chat-repeat 15000 \
+  --keys keyW,keyA,keyS,keyD \
+  --max-active 1
+```
+
 ## 🧩 Use Cases
 
 - **Virtual Events & Conferences** - Host live gatherings with spatial audio

--- a/agent.mjs
+++ b/agent.mjs
@@ -1,69 +1,409 @@
 import { createNodeClientWorld } from './build/world-node-client.js'
 
-const world = createNodeClientWorld()
+const DEFAULT_CONFIG = {
+  wsUrl: 'ws://localhost:3000/ws',
+  name: undefined,
+  avatar: undefined,
+  movementEnabled: true,
+  moveMode: 'wander',
+  wanderKeys: ['keyW', 'keyA', 'keyS', 'keyD', 'space', 'shiftLeft'],
+  wanderIntervalMs: 350,
+  wanderPressProbability: 0.6,
+  wanderMaxActive: 2,
+  chatEnabled: true,
+  chatMessage: 'heyo...',
+  chatDelayMs: 2000,
+  chatRepeatMs: 0,
+  autoReconnect: true,
+  reconnectDelayMs: 2000,
+  verbose: true,
+}
 
-const wsUrl = 'ws://localhost:3000/ws'
+const config = buildConfig()
+const log = createLogger(config.verbose)
+let world
+let sessionCleanup
+let reconnectTimer
+let shuttingDown = false
 
-// TODO:
-// - running two of these fails the second one because they both try to use the same authToken and get kicked (one per world)
+start()
 
-world.init({
-  wsUrl,
-  // name: 'Hypermon',
-  // avatar: 'url to a vrm...',
-})
-
-let handle
-
-world.once('ready', () => {
-  handle = start()
-})
-world.on('kick', () => {
-  handle?.()
-  handle = null
-})
-world.on('disconnect', () => {
-  handle?.()
-  handle = null
-  world.destroy()
-})
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
 
 function start() {
-  let timerId
-  let elapsed = 0
-  let spoken
+  clearTimeout(reconnectTimer)
+  world = createWorld()
+  log('connecting to world', config.wsUrl)
+  world.init(filterUndefined({
+    wsUrl: config.wsUrl,
+    name: config.name,
+    avatar: config.avatar,
+  }))
+}
 
-  const keys = ['keyW', 'keyA', 'keyS', 'keyD', 'space', 'shiftLeft']
+function createWorld() {
+  const instance = createNodeClientWorld()
 
-  function next() {
-    const key = keys[num(0, keys.length - 1)]
-    num(0, 10) < 5 ? press(key) : release(key)
-    timerId = setTimeout(next, 0.3 * 1000)
-    elapsed += 0.3
-    if (elapsed > 2 && !spoken) {
-      world.chat.send('heyo...')
-      spoken = true
+  instance.once('ready', () => {
+    log('world ready')
+    sessionCleanup = startSession(instance)
+  })
+
+  instance.on('kick', payload => {
+    log('kicked from world', payload?.reason ?? '')
+    teardownSession(instance)
+    scheduleReconnect()
+  })
+
+  instance.on('disconnect', payload => {
+    log('disconnected from world', payload?.reason ?? '')
+    teardownSession(instance)
+    scheduleReconnect()
+  })
+
+  instance.on('error', error => {
+    console.error('[agent:error]', error)
+  })
+
+  return instance
+}
+
+function startSession(instance) {
+  const cleanups = []
+
+  if (config.movementEnabled && config.moveMode !== 'idle') {
+    if (config.moveMode === 'wander') {
+      cleanups.push(startWanderMovement(instance))
+    } else {
+      log('unknown move mode, skipping movement control:', config.moveMode)
     }
   }
 
-  next()
-
-  function press(prop) {
-    console.log('press:', prop)
-    world.controls.simulateButton(prop, true)
+  if (config.chatEnabled && config.chatMessage) {
+    cleanups.push(startChat(instance))
   }
 
-  function release(prop) {
-    console.log('release:', prop)
-    world.controls.simulateButton(prop, false)
+  log('session started', {
+    movement: config.movementEnabled ? config.moveMode : 'disabled',
+    chat: config.chatEnabled && config.chatMessage ? 'enabled' : 'disabled',
+  })
+
+  return () => {
+    cleanups.forEach(stop => stop?.())
   }
+}
+
+function startWanderMovement(instance) {
+  const keys = Array.isArray(config.wanderKeys) ? config.wanderKeys.filter(Boolean) : []
+  if (keys.length === 0) {
+    log('no keys configured for wander movement, skipping')
+    return () => {}
+  }
+
+  const pressed = new Map(keys.map(key => [key, false]))
+  const activeKeys = new Set()
+  const maxActive = Math.max(0, Math.floor(config.wanderMaxActive ?? 0))
+  const intervalMs = Math.max(50, Math.floor(config.wanderIntervalMs ?? DEFAULT_CONFIG.wanderIntervalMs))
+  const pressProbability = clamp(config.wanderPressProbability ?? DEFAULT_CONFIG.wanderPressProbability, 0, 1)
+  let timerId
+
+  log('movement:wander config', {
+    intervalMs,
+    pressProbability,
+    maxActive: maxActive || 'unbounded',
+    keys,
+  })
+
+  function tick() {
+    const key = choose(keys)
+    const shouldPress = Math.random() < pressProbability
+    if (shouldPress) {
+      requestPress(key)
+    } else {
+      requestRelease(key)
+    }
+    timerId = setTimeout(tick, intervalMs)
+  }
+
+  function requestPress(key) {
+    if (pressed.get(key)) return
+    if (maxActive > 0 && activeKeys.size >= maxActive) {
+      const victim = choose(Array.from(activeKeys))
+      if (victim) {
+        applyState(victim, false)
+      }
+    }
+    applyState(key, true)
+  }
+
+  function requestRelease(key) {
+    if (!pressed.get(key)) return
+    applyState(key, false)
+  }
+
+  function applyState(key, nextState) {
+    const current = pressed.get(key)
+    if (current === nextState) return
+    pressed.set(key, nextState)
+    if (nextState) {
+      activeKeys.add(key)
+    } else {
+      activeKeys.delete(key)
+    }
+    instance.controls.simulateButton(key, nextState)
+    log('movement', nextState ? 'press' : 'release', key)
+  }
+
+  tick()
+
+  return () => {
+    clearTimeout(timerId)
+    keys.forEach(key => applyState(key, false))
+    activeKeys.clear()
+  }
+}
+
+function startChat(instance) {
+  const delay = Math.max(0, Math.floor(config.chatDelayMs ?? DEFAULT_CONFIG.chatDelayMs))
+  const repeat = Math.max(0, Math.floor(config.chatRepeatMs ?? 0))
+  const message = config.chatMessage
+  let timerId
+
+  log('chat config', {
+    message,
+    delay,
+    repeat,
+  })
+
+  function sendMessage() {
+    instance.chat.send(message)
+    log('chat sent', message)
+    if (repeat > 0) {
+      timerId = setTimeout(sendMessage, repeat)
+    }
+  }
+
+  timerId = setTimeout(sendMessage, delay)
 
   return () => {
     clearTimeout(timerId)
   }
 }
 
-function num(min, max, dp = 0) {
-  const value = Math.random() * (max - min) + min
-  return parseFloat(value.toFixed(dp))
+function scheduleReconnect() {
+  if (!config.autoReconnect) {
+    log('auto reconnect disabled, shutting down')
+    shutdown()
+    return
+  }
+  if (shuttingDown) return
+  if (reconnectTimer) return
+  log('scheduling reconnect in', config.reconnectDelayMs, 'ms')
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null
+    teardownWorld()
+    if (!shuttingDown) {
+      start()
+    }
+  }, Math.max(1000, Math.floor(config.reconnectDelayMs ?? DEFAULT_CONFIG.reconnectDelayMs)))
+}
+
+function teardownSession(instance) {
+  sessionCleanup?.()
+  sessionCleanup = null
+  try {
+    instance.controls?.reset?.()
+  } catch (error) {
+    log('failed to reset controls', error?.message ?? error)
+  }
+  try {
+    instance.destroy?.()
+  } catch (error) {
+    log('failed to destroy world instance', error?.message ?? error)
+  }
+}
+
+function teardownWorld() {
+  if (world) {
+    try {
+      world.destroy?.()
+    } catch (error) {
+      log('failed to destroy world during teardown', error?.message ?? error)
+    }
+    world = null
+  }
+}
+
+function shutdown() {
+  if (shuttingDown) return
+  shuttingDown = true
+  log('shutting down agent')
+  clearTimeout(reconnectTimer)
+  reconnectTimer = null
+  sessionCleanup?.()
+  sessionCleanup = null
+  teardownWorld()
+  process.exit(0)
+}
+
+function buildConfig() {
+  const envConfig = {
+    wsUrl: process.env.HYPERFY_AGENT_WS_URL,
+    name: process.env.HYPERFY_AGENT_NAME,
+    avatar: process.env.HYPERFY_AGENT_AVATAR,
+    movementEnabled: parseBoolean(process.env.HYPERFY_AGENT_MOVE_ENABLED),
+    moveMode: process.env.HYPERFY_AGENT_MOVE_MODE,
+    wanderKeys: parseList(process.env.HYPERFY_AGENT_WANDER_KEYS),
+    wanderIntervalMs: parseNumber(process.env.HYPERFY_AGENT_WANDER_INTERVAL_MS),
+    wanderPressProbability: parseNumber(process.env.HYPERFY_AGENT_WANDER_PRESS_PROBABILITY),
+    wanderMaxActive: parseNumber(process.env.HYPERFY_AGENT_WANDER_MAX_ACTIVE),
+    chatEnabled: parseBoolean(process.env.HYPERFY_AGENT_CHAT_ENABLED),
+    chatMessage: process.env.HYPERFY_AGENT_CHAT_MESSAGE,
+    chatDelayMs: parseNumber(process.env.HYPERFY_AGENT_CHAT_DELAY_MS),
+    chatRepeatMs: parseNumber(process.env.HYPERFY_AGENT_CHAT_REPEAT_MS),
+    autoReconnect: parseBoolean(process.env.HYPERFY_AGENT_AUTO_RECONNECT),
+    reconnectDelayMs: parseNumber(process.env.HYPERFY_AGENT_RECONNECT_DELAY_MS),
+    verbose: parseBoolean(process.env.HYPERFY_AGENT_VERBOSE),
+  }
+
+  const args = parseArgs(process.argv.slice(2))
+  const cliConfig = {}
+
+  if ('wsUrl' in args) cliConfig.wsUrl = args.wsUrl
+  if ('name' in args) cliConfig.name = args.name
+  if ('avatar' in args) cliConfig.avatar = args.avatar
+  if ('moveMode' in args) cliConfig.moveMode = args.moveMode
+  if ('wanderKeys' in args) cliConfig.wanderKeys = parseList(args.wanderKeys)
+  if ('keys' in args) cliConfig.wanderKeys = parseList(args.keys)
+  if ('wanderIntervalMs' in args) cliConfig.wanderIntervalMs = parseNumber(args.wanderIntervalMs)
+  if ('interval' in args) cliConfig.wanderIntervalMs = parseNumber(args.interval)
+  if ('wanderPressProbability' in args) cliConfig.wanderPressProbability = parseNumber(args.wanderPressProbability)
+  if ('pressProbability' in args) cliConfig.wanderPressProbability = parseNumber(args.pressProbability)
+  if ('wanderMaxActive' in args) cliConfig.wanderMaxActive = parseNumber(args.wanderMaxActive)
+  if ('maxActive' in args) cliConfig.wanderMaxActive = parseNumber(args.maxActive)
+  if ('chatMessage' in args) cliConfig.chatMessage = args.chatMessage
+  if ('chatDelayMs' in args) cliConfig.chatDelayMs = parseNumber(args.chatDelayMs)
+  if ('chatDelay' in args) cliConfig.chatDelayMs = parseNumber(args.chatDelay)
+  if ('chatRepeatMs' in args) cliConfig.chatRepeatMs = parseNumber(args.chatRepeatMs)
+  if ('chatRepeat' in args) cliConfig.chatRepeatMs = parseNumber(args.chatRepeat)
+  if ('reconnectDelayMs' in args) cliConfig.reconnectDelayMs = parseNumber(args.reconnectDelayMs)
+  if ('reconnectDelay' in args) cliConfig.reconnectDelayMs = parseNumber(args.reconnectDelay)
+
+  if ('move' in args) cliConfig.movementEnabled = resolveBoolean(args.move)
+  if ('chat' in args) cliConfig.chatEnabled = resolveBoolean(args.chat)
+  if ('autoReconnect' in args) cliConfig.autoReconnect = resolveBoolean(args.autoReconnect)
+  if ('verbose' in args) cliConfig.verbose = resolveBoolean(args.verbose)
+  if ('silent' in args) cliConfig.verbose = !resolveBoolean(args.silent)
+
+  const merged = {
+    ...DEFAULT_CONFIG,
+    ...filterUndefined(envConfig),
+    ...filterUndefined(cliConfig),
+  }
+
+  if (!merged.movementEnabled) {
+    merged.moveMode = 'idle'
+  }
+
+  if (!merged.chatEnabled) {
+    merged.chatMessage = ''
+  }
+
+  merged.wanderKeys = Array.isArray(merged.wanderKeys)
+    ? merged.wanderKeys.map(value => String(value).trim()).filter(Boolean)
+    : DEFAULT_CONFIG.wanderKeys.slice()
+
+  return merged
+}
+
+function parseArgs(tokens) {
+  const result = {}
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]
+    if (!token.startsWith('--')) continue
+    const withoutPrefix = token.slice(2)
+    if (withoutPrefix.startsWith('no-')) {
+      const key = toCamelCase(withoutPrefix.slice(3))
+      result[key] = false
+      continue
+    }
+    const eqIndex = withoutPrefix.indexOf('=')
+    if (eqIndex !== -1) {
+      const key = toCamelCase(withoutPrefix.slice(0, eqIndex))
+      const value = withoutPrefix.slice(eqIndex + 1)
+      result[key] = value
+      continue
+    }
+    const key = toCamelCase(withoutPrefix)
+    const next = tokens[index + 1]
+    if (!next || next.startsWith('--')) {
+      result[key] = true
+    } else {
+      result[key] = next
+      index += 1
+    }
+  }
+  return result
+}
+
+function resolveBoolean(value) {
+  if (typeof value === 'boolean') return value
+  const normalized = parseBoolean(value)
+  if (typeof normalized === 'boolean') return normalized
+  return true
+}
+
+function parseBoolean(value) {
+  if (value === undefined || value === null) return undefined
+  if (typeof value === 'boolean') return value
+  const normalized = String(value).trim().toLowerCase()
+  if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) return true
+  if (['false', '0', 'no', 'n', 'off'].includes(normalized)) return false
+  return undefined
+}
+
+function parseNumber(value) {
+  if (value === undefined || value === null || value === '') return undefined
+  const number = Number(value)
+  return Number.isFinite(number) ? number : undefined
+}
+
+function parseList(value) {
+  if (!value) return undefined
+  if (Array.isArray(value)) return value
+  return String(value)
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+function clamp(value, min, max) {
+  const number = Number(value)
+  if (!Number.isFinite(number)) return min
+  return Math.min(Math.max(number, min), max)
+}
+
+function choose(list) {
+  if (!Array.isArray(list) || list.length === 0) return undefined
+  const index = Math.floor(Math.random() * list.length)
+  return list[index]
+}
+
+function filterUndefined(object) {
+  return Object.fromEntries(
+    Object.entries(object || {}).filter(([, value]) => value !== undefined)
+  )
+}
+
+function toCamelCase(value) {
+  return value.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
+}
+
+function createLogger(enabled) {
+  if (!enabled) return () => {}
+  return (...args) => {
+    const timestamp = new Date().toISOString()
+    console.log(`[agent ${timestamp}]`, ...args)
+  }
 }


### PR DESCRIPTION
## Summary
- replace the simple agent bootstrap with a configurable controller that supports scripted movement, chat cadence, logging, and auto-reconnect behaviour
- add helper utilities for parsing CLI flags and environment variables to drive the agent without editing source
- document the automation agent workflow in the README, including common configuration flags and an end-to-end usage example

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated client/core files)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc4514470832dabe43df45c4e2413