### PR TITLE
Add AI companion system with procedural registry and UI

### DIFF
--- a/src/client/components/Sidebar.js
+++ b/src/client/components/Sidebar.js
@@ -192,18 +192,25 @@ export function Sidebar({ world, ui }) {
             >
               <BookTextIcon size='1.25rem' />
             </Btn> */}
-              <Btn
-                active={activePane === 'apps'}
-                suspended={ui.pane === 'apps' && !activePane}
-                onClick={() => world.ui.togglePane('apps')}
-              >
-                <LayersIcon size='1.25rem' />
-              </Btn>
-              <Btn
-                active={activePane === 'add'}
-                suspended={ui.pane === 'add' && !activePane}
-                onClick={() => world.ui.togglePane('add')}
-              >
+            <Btn
+              active={activePane === 'apps'}
+              suspended={ui.pane === 'apps' && !activePane}
+              onClick={() => world.ui.togglePane('apps')}
+            >
+              <LayersIcon size='1.25rem' />
+            </Btn>
+            <Btn
+              active={activePane === 'companions'}
+              suspended={ui.pane === 'companions' && !activePane}
+              onClick={() => world.ui.togglePane('companions')}
+            >
+              <SparkleIcon size='1.25rem' />
+            </Btn>
+            <Btn
+              active={activePane === 'add'}
+              suspended={ui.pane === 'add' && !activePane}
+              onClick={() => world.ui.togglePane('add')}
+            >
                 <CirclePlusIcon size='1.25rem' />
               </Btn>
             </Section>
@@ -244,6 +251,7 @@ export function Sidebar({ world, ui }) {
         {ui.pane === 'prefs' && <Prefs world={world} hidden={!ui.active} />}
         {ui.pane === 'world' && <World world={world} hidden={!ui.active} />}
         {ui.pane === 'apps' && <Apps world={world} hidden={!ui.active} />}
+        {ui.pane === 'companions' && <CompanionsPane world={world} hidden={!ui.active} />}
         {ui.pane === 'add' && <Add world={world} hidden={!ui.active} />}
         {ui.pane === 'app' && <App key={ui.app.data.id} world={world} hidden={!ui.active} />}
         {ui.pane === 'script' && <Script key={ui.app.data.id} world={world} hidden={!ui.active} />}
@@ -1888,6 +1896,477 @@ function Players({ world, hidden }) {
               )}
             </div>
           ))}
+        </div>
+      </div>
+    </Pane>
+  )
+}
+
+function CompanionsPane({ world, hidden }) {
+  const localPlayer = world.entities.player
+  const { isBuilder } = useRank(world, localPlayer)
+  const [state, setState] = useState(() => world.companions.getState())
+  const [selectedId, setSelectedId] = useState(() => state.registry[0]?.id || null)
+  const [draft, setDraft] = useState(() => (state.registry[0] ? cloneDeep(state.registry[0]) : null))
+  useEffect(() => {
+    const onChange = next => {
+      setState(next)
+    }
+    world.companions.on('change', onChange)
+    return () => {
+      world.companions.off('change', onChange)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!selectedId || !state.registry.find(item => item.id === selectedId)) {
+      setSelectedId(state.registry[0]?.id || null)
+    }
+  }, [state, selectedId])
+
+  useEffect(() => {
+    if (!selectedId) {
+      setDraft(null)
+      return
+    }
+    const selected = state.registry.find(item => item.id === selectedId)
+    setDraft(selected ? cloneDeep(selected) : null)
+  }, [selectedId, state])
+
+  const registry = state.registry
+  const assignments = state.assignments || {}
+
+  const players = useMemo(() => {
+    if (!isBuilder && localPlayer) return [localPlayer]
+    return getPlayers(world)
+  }, [isBuilder, localPlayer, state.assignments])
+
+  const companionOptions = useMemo(() => {
+    return registry.map(item => ({ label: item.name, value: item.id }))
+  }, [registry])
+
+  const handleSelect = id => {
+    setSelectedId(id)
+  }
+
+  const commit = updater => value => {
+    if (!draft) return
+    if (!isBuilder) return
+    setDraft(prev => {
+      if (!prev) return prev
+      const next = cloneDeep(prev)
+      updater(next, value)
+      return next
+    })
+  }
+
+  const save = () => {
+    if (!draft || !isBuilder) return
+    world.companions.update(draft.id, draft)
+  }
+
+  const remove = () => {
+    if (!draft || !isBuilder) return
+    world.companions.remove(draft.id)
+  }
+
+  const setDefault = () => {
+    if (!draft || !isBuilder) return
+    world.companions.update(draft.id, { metadata: { default: true } })
+  }
+
+  const createManual = () => {
+    world.companions.create({ name: 'New Companion' })
+  }
+
+  const generate = () => {
+    world.companions.generate({})
+  }
+
+  const assignPlayer = (playerId, value) => {
+    if (value === '__auto__') {
+      world.companions.assignToPlayer(playerId, null)
+    } else {
+      world.companions.assignToPlayer(playerId, value)
+    }
+  }
+
+  const selected = draft
+
+  return (
+    <Pane hidden={hidden} width='34rem'>
+      <div
+        className='companions'
+        css={css`
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          background: rgba(11, 10, 21, 0.9);
+          border: 1px solid rgba(255, 255, 255, 0.05);
+          border-radius: 1.375rem;
+          overflow: hidden;
+          .companions-head {
+            padding: 1rem;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+          }
+          .companions-title {
+            flex: 1;
+            font-weight: 500;
+            font-size: 1rem;
+          }
+          .companions-actions {
+            display: flex;
+            gap: 0.5rem;
+            button {
+              height: 2rem;
+              padding: 0 0.9rem;
+              font-size: 0.875rem;
+              border-radius: 1rem;
+              border: 1px solid rgba(255, 255, 255, 0.1);
+              background: rgba(255, 255, 255, 0.05);
+              color: white;
+              cursor: pointer;
+              &:hover {
+                background: rgba(255, 255, 255, 0.1);
+              }
+            }
+          }
+          .companions-body {
+            display: flex;
+            flex: 1;
+            overflow: hidden;
+          }
+          .companions-list {
+            width: 11rem;
+            border-right: 1px solid rgba(255, 255, 255, 0.05);
+            overflow-y: auto;
+          }
+          .companions-item {
+            padding: 0.75rem 1rem;
+            cursor: pointer;
+            font-size: 0.9375rem;
+            border-left: 0.25rem solid transparent;
+            &:hover {
+              background: rgba(255, 255, 255, 0.04);
+            }
+            &.active {
+              border-left-color: rgba(126, 214, 255, 0.9);
+              background: rgba(126, 214, 255, 0.08);
+            }
+          }
+          .companions-detail {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            overflow-y: auto;
+          }
+          .companions-section {
+            padding: 0.75rem 1rem;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+            .section-title {
+              font-size: 0.8125rem;
+              letter-spacing: 0.05em;
+              text-transform: uppercase;
+              margin-bottom: 0.5rem;
+              color: rgba(255, 255, 255, 0.6);
+            }
+          }
+          .companions-footer {
+            padding: 0.75rem 1rem;
+            border-top: 1px solid rgba(255, 255, 255, 0.05);
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+          }
+          .companions-footer button {
+            height: 2.5rem;
+            border-radius: 1.25rem;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.08);
+            color: white;
+            cursor: pointer;
+            font-size: 0.9375rem;
+            &:hover {
+              background: rgba(255, 255, 255, 0.15);
+            }
+            &.danger {
+              background: rgba(255, 90, 90, 0.12);
+              border-color: rgba(255, 90, 90, 0.4);
+              &:hover {
+                background: rgba(255, 90, 90, 0.2);
+              }
+            }
+          }
+        `}
+      >
+        <div className='companions-head'>
+          <div className='companions-title'>AI Companions</div>
+          <div className='companions-actions'>
+            {isBuilder && (
+              <>
+                <button onClick={generate}>Generate</button>
+                <button onClick={createManual}>New Manual</button>
+              </>
+            )}
+          </div>
+        </div>
+        <div className='companions-body'>
+          <div className='companions-list'>
+            {registry.map(item => (
+              <div
+                key={item.id}
+                className={cls('companions-item', { active: item.id === selectedId })}
+                onClick={() => handleSelect(item.id)}
+              >
+                <div>{item.name}</div>
+                {item.metadata?.rarity && (
+                  <div
+                    css={css`
+                      font-size: 0.75rem;
+                      opacity: 0.7;
+                    `}
+                  >
+                    {item.metadata.rarity}
+                  </div>
+                )}
+              </div>
+            ))}
+            {registry.length === 0 && (
+              <div
+                css={css`
+                  padding: 1rem;
+                  font-size: 0.9rem;
+                  opacity: 0.7;
+                `}
+              >
+                No companions yet.
+              </div>
+            )}
+          </div>
+          <div className='companions-detail'>
+            {selected ? (
+              <>
+                <div className='companions-section'>
+                  <div className='section-title'>Identity</div>
+                  <FieldText
+                    label='Name'
+                    value={selected.name || ''}
+                    onChange={commit((next, value) => {
+                      next.name = value
+                    })}
+                  />
+                  <FieldText
+                    label='Title'
+                    value={selected.title || ''}
+                    onChange={commit((next, value) => {
+                      next.title = value
+                    })}
+                  />
+                  <FieldText
+                    label='Archetype'
+                    value={selected.archetype || ''}
+                    onChange={commit((next, value) => {
+                      next.archetype = value
+                    })}
+                  />
+                  <FieldTextarea
+                    label='Persona'
+                    value={selected.persona || ''}
+                    onChange={commit((next, value) => {
+                      next.persona = value
+                    })}
+                  />
+                </div>
+                <div className='companions-section'>
+                  <div className='section-title'>Appearance</div>
+                  <FieldText
+                    label='Model / Avatar'
+                    value={selected.appearance?.url || ''}
+                    onChange={commit((next, value) => {
+                      next.appearance = next.appearance || {}
+                      next.appearance.url = value
+                    })}
+                  />
+                  <FieldNumber
+                    label='Scale'
+                    dp={2}
+                    min={0.1}
+                    max={4}
+                    step={0.1}
+                    value={selected.appearance?.scale ?? 1}
+                    onChange={commit((next, value) => {
+                      next.appearance = next.appearance || {}
+                      next.appearance.scale = value
+                    })}
+                  />
+                </div>
+                <div className='companions-section'>
+                  <div className='section-title'>Behavior</div>
+                  <FieldNumber
+                    label='Follow Distance'
+                    dp={2}
+                    min={0.5}
+                    max={8}
+                    step={0.1}
+                    value={selected.behavior?.followDistance ?? 2.5}
+                    onChange={commit((next, value) => {
+                      next.behavior = next.behavior || {}
+                      next.behavior.followDistance = value
+                    })}
+                  />
+                  <FieldNumber
+                    label='Follow Height'
+                    dp={2}
+                    min={-2}
+                    max={4}
+                    step={0.1}
+                    value={selected.behavior?.followHeight ?? 0}
+                    onChange={commit((next, value) => {
+                      next.behavior = next.behavior || {}
+                      next.behavior.followHeight = value
+                    })}
+                  />
+                  <FieldNumber
+                    label='Speed'
+                    dp={2}
+                    min={1}
+                    max={8}
+                    step={0.1}
+                    value={selected.behavior?.movementSpeed ?? 3}
+                    onChange={commit((next, value) => {
+                      next.behavior = next.behavior || {}
+                      next.behavior.movementSpeed = value
+                    })}
+                  />
+                  <FieldToggle
+                    label='Idle Orbit'
+                    value={selected.behavior?.idleOrbit ?? true}
+                    onChange={commit((next, value) => {
+                      next.behavior = next.behavior || {}
+                      next.behavior.idleOrbit = value
+                    })}
+                  />
+                </div>
+                <div className='companions-section'>
+                  <div className='section-title'>Locomotion</div>
+                  <FieldToggle
+                    label='Walk'
+                    value={selected.locomotion?.walk ?? true}
+                    onChange={commit((next, value) => {
+                      next.locomotion = next.locomotion || {}
+                      next.locomotion.walk = value
+                    })}
+                  />
+                  <FieldToggle
+                    label='Swim'
+                    value={selected.locomotion?.swim ?? false}
+                    onChange={commit((next, value) => {
+                      next.locomotion = next.locomotion || {}
+                      next.locomotion.swim = value
+                    })}
+                  />
+                  <FieldToggle
+                    label='Fly'
+                    value={selected.locomotion?.fly ?? false}
+                    onChange={commit((next, value) => {
+                      next.locomotion = next.locomotion || {}
+                      next.locomotion.fly = value
+                    })}
+                  />
+                  <FieldToggle
+                    label='Hover'
+                    value={selected.locomotion?.hover ?? false}
+                    onChange={commit((next, value) => {
+                      next.locomotion = next.locomotion || {}
+                      next.locomotion.hover = value
+                    })}
+                  />
+                  <FieldToggle
+                    label='Dig'
+                    value={selected.locomotion?.dig ?? false}
+                    onChange={commit((next, value) => {
+                      next.locomotion = next.locomotion || {}
+                      next.locomotion.dig = value
+                    })}
+                  />
+                </div>
+                <div className='companions-section'>
+                  <div className='section-title'>Instructions</div>
+                  <FieldTextarea
+                    label='Chat Style'
+                    value={selected.instructions?.chat || ''}
+                    onChange={commit((next, value) => {
+                      next.instructions = next.instructions || {}
+                      next.instructions.chat = value
+                    })}
+                  />
+                  <FieldTextarea
+                    label='Combat Notes'
+                    value={selected.instructions?.combat || ''}
+                    onChange={commit((next, value) => {
+                      next.instructions = next.instructions || {}
+                      next.instructions.combat = value
+                    })}
+                  />
+                  <FieldTextarea
+                    label='Exploration Notes'
+                    value={selected.instructions?.exploration || ''}
+                    onChange={commit((next, value) => {
+                      next.instructions = next.instructions || {}
+                      next.instructions.exploration = value
+                    })}
+                  />
+                </div>
+              </>
+            ) : (
+              <div
+                css={css`
+                  padding: 1.5rem;
+                  font-size: 0.95rem;
+                  opacity: 0.7;
+                `}
+              >
+                Select a companion to edit.
+              </div>
+            )}
+          </div>
+        </div>
+        <div className='companions-footer'>
+          <div
+            css={css`
+              font-size: 0.8125rem;
+              letter-spacing: 0.05em;
+              text-transform: uppercase;
+              color: rgba(255, 255, 255, 0.6);
+            `}
+          >
+            Assignments
+          </div>
+          {players.map(player => {
+            const value = assignments[player.data.id] || '__auto__'
+            const options = [{ label: 'Auto', value: '__auto__' }, ...companionOptions]
+            return (
+              <FieldSwitch
+                key={player.data.id}
+                label={player.data.name}
+                value={value}
+                options={options}
+                onChange={val => assignPlayer(player.data.id, val)}
+              />
+            )
+          })}
+          {selected && isBuilder && (
+            <>
+              <button onClick={save}>Save Changes</button>
+              <button onClick={setDefault}>Set as Default</button>
+              <button className='danger' onClick={remove}>
+                Remove Companion
+              </button>
+            </>
+          )}
         </div>
       </div>
     </Pane>

--- a/src/core/World.js
+++ b/src/core/World.js
@@ -13,6 +13,7 @@ import { Entities } from './systems/Entities'
 import { Physics } from './systems/Physics'
 import { Stage } from './systems/Stage'
 import { Scripts } from './systems/Scripts'
+import { Companions } from './systems/Companions'
 
 export class World extends EventEmitter {
   constructor() {
@@ -45,6 +46,7 @@ export class World extends EventEmitter {
     this.register('chat', Chat)
     this.register('blueprints', Blueprints)
     this.register('entities', Entities)
+    this.register('companions', Companions)
     this.register('physics', Physics)
     this.register('stage', Stage)
   }

--- a/src/core/entities/Companion.js
+++ b/src/core/entities/Companion.js
@@ -1,0 +1,305 @@
+import * as THREE from '../extras/three'
+import { Entity } from './Entity'
+import { createNode } from '../extras/createNode'
+import { CompanionControlRig } from '../extras/CompanionControlRig'
+
+const FOLLOW_UP = new THREE.Vector3(0, 1, 0)
+const v1 = new THREE.Vector3()
+const v2 = new THREE.Vector3()
+const v3 = new THREE.Vector3()
+const q1 = new THREE.Quaternion()
+
+const DEFAULT_BEHAVIOR = {
+  followDistance: 2.5,
+  followHeight: 0,
+  followResponsiveness: 3,
+  tetherRadius: 14,
+  idleOrbit: true,
+  idleOrbitRadius: 1.5,
+  idleOrbitSpeed: 0.4,
+  manualTimeout: 2.5,
+  movementSpeed: 3,
+}
+
+const DEFAULT_LOCOMOTION = {
+  walk: true,
+  swim: false,
+  fly: false,
+  hover: false,
+  dig: false,
+}
+
+const DEFAULT_APPEARANCE = {
+  type: 'avatar',
+  url: 'asset://avatar.vrm',
+  scale: 1,
+  tint: '#ffffff',
+  idleAnimation: null,
+  locomotionSet: 'humanoid',
+}
+
+export class Companion extends Entity {
+  constructor(world, data, local) {
+    super(world, data, local)
+    this.isCompanion = true
+    this.isAI = true
+    this.behavior = { ...DEFAULT_BEHAVIOR, ...(data.behavior || {}) }
+    this.locomotion = { ...DEFAULT_LOCOMOTION, ...(data.locomotion || {}) }
+    this.appearance = { ...DEFAULT_APPEARANCE, ...(data.appearance || {}) }
+    this.instructions = data.instructions || {}
+    this.skills = data.skills || []
+    this.persona = data.persona || ''
+    this.title = data.title || null
+
+    this.data.behavior = this.behavior
+    this.data.locomotion = this.locomotion
+    this.data.appearance = this.appearance
+    this.data.instructions = this.instructions
+    this.data.skills = this.skills
+
+    this.manualChatDuration = 4
+    this.chatTimer = 0
+    this.chatDuration = 0
+    this.chatText = ''
+
+    this.controller = new CompanionControlRig(this, {
+      manualTimeout: this.behavior.manualTimeout,
+      movementSpeed: this.behavior.movementSpeed,
+      canFly: this.locomotion.fly || this.locomotion.hover,
+    })
+
+    this.idleAngle = Math.random() * Math.PI * 2
+
+    this.init()
+  }
+
+  init() {
+    this.base = createNode('group')
+    this.base.position.fromArray(this.data.position || [0, 0, 0])
+    this.base.quaternion.fromArray(this.data.quaternion || [0, 0, 0, 1])
+
+    this.aura = createNode('group')
+
+    const nametagLabel = this.data.displayName || this.data.name || this.data.id || 'Companion'
+    this.nametag = createNode('nametag', {
+      label: nametagLabel,
+      subtitle: this.title || null,
+      active: true,
+    })
+    this.aura.add(this.nametag)
+
+    this.bubble = createNode('ui', {
+      width: 340,
+      height: 480,
+      pivot: 'bottom-center',
+      billboard: 'full',
+      scaler: [3, 30],
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+      active: false,
+    })
+    this.bubbleBox = createNode('uiview', {
+      backgroundColor: 'rgba(15, 12, 28, 0.8)',
+      borderRadius: 12,
+      padding: 14,
+    })
+    this.bubbleText = createNode('uitext', {
+      color: 'white',
+      fontWeight: 300,
+      lineHeight: 1.4,
+      fontSize: 16,
+    })
+    this.bubble.add(this.bubbleBox)
+    this.bubbleBox.add(this.bubbleText)
+    this.aura.add(this.bubble)
+
+    this.aura.activate({ world: this.world, entity: this })
+    this.base.activate({ world: this.world, entity: this })
+
+    this.applyAppearance()
+
+    this.world.setHot(this, true)
+  }
+
+  get owner() {
+    const ownerId = this.data.ownerId || this.data.owner
+    if (!ownerId) return null
+    return this.world.entities.get(ownerId)
+  }
+
+  applyAppearance() {
+    if (!this.world.loader || this.world.network?.isServer) return
+    const url = this.appearance.url || DEFAULT_APPEARANCE.url
+    if (this.appearance.type === 'avatar' || url.endsWith('.vrm')) {
+      this.world.loader.load('avatar', url).then(src => {
+        if (this.avatar) this.avatar.deactivate()
+        this.avatar = src.toNodes().get('avatar')
+        if (!this.avatar) return
+        this.avatar.scale.setScalar(this.appearance.scale || 1)
+        this.base.add(this.avatar)
+        const headHeight = this.avatar.getHeadToHeight?.() || 1.8
+        this.nametag.position.y = headHeight + 0.25
+        this.bubble.position.y = headHeight + 0.25
+        if (this.appearance.tint && this.avatar.instance?.setTint) {
+          this.avatar.instance.setTint(this.appearance.tint)
+        }
+      })
+      return
+    }
+    const type = 'model'
+    this.world.loader.load(type, url).then(src => {
+      if (this.avatar) this.avatar.deactivate()
+      this.avatar = src.toNodes().get('model')
+      if (!this.avatar) return
+      this.avatar.scale.setScalar(this.appearance.scale || 1)
+      this.base.add(this.avatar)
+      const height = this.appearance.height || 1.6
+      this.nametag.position.y = height + 0.25
+      this.bubble.position.y = height + 0.25
+    })
+  }
+
+  speak(text, { duration, from } = {}) {
+    if (!text) return
+    this.chatText = text
+    this.chatDuration = duration || this.manualChatDuration
+    this.chatTimer = 0
+    this.bubbleText.text = text
+    this.bubble.active = true
+    this.world.events.emit('companion:chat', {
+      companionId: this.data.id,
+      playerId: this.data.ownerId,
+      text,
+      from: from || 'companion',
+    })
+  }
+
+  applyDirective(directive) {
+    if (!directive) return
+    if (directive.type === 'chat') {
+      this.speak(directive.text, directive)
+      return
+    }
+    if (directive.type === 'input') {
+      this.controller.applyInput(directive)
+      return
+    }
+    if (directive.type === 'state') {
+      this.data.state = { ...this.data.state, ...(directive.state || {}) }
+      return
+    }
+    if (directive.type === 'action') {
+      const action = directive.action
+      if (!action) return
+      this.world.events.emit('companion:action', {
+        companionId: this.data.id,
+        playerId: this.data.ownerId,
+        action,
+      })
+      return
+    }
+  }
+
+  update(delta) {
+    const manualActive = this.controller.update(delta)
+
+    if (!manualActive) {
+      this.updateFollow(delta)
+    }
+
+    this.updateChat(delta)
+
+    if (this.avatar?.instance?.update) {
+      this.avatar.instance.update(delta)
+      const matrix = this.avatar.getBoneTransform?.('head')
+      if (matrix) {
+        this.aura.position.setFromMatrixPosition(matrix)
+      } else {
+        this.aura.position.copy(this.base.position).add(FOLLOW_UP)
+      }
+    } else {
+      this.aura.position.copy(this.base.position).add(FOLLOW_UP)
+    }
+  }
+
+  updateFollow(delta) {
+    const owner = this.owner
+    if (!owner || !owner.base) return
+
+    const followDistance = this.behavior.followDistance
+    const followHeight = this.behavior.followHeight
+    const responsiveness = Math.max(this.behavior.followResponsiveness || 1, 0.0001)
+
+    owner.base.getWorldDirection(v1)
+    v1.multiplyScalar(-followDistance)
+
+    const ownerPos = owner.base.position
+    v2.copy(ownerPos).add(v1)
+    v2.y += followHeight
+
+    const tetherRadius = this.behavior.tetherRadius || 0
+    if (tetherRadius > 0) {
+      const dist = v3.copy(ownerPos).sub(this.base.position).length()
+      if (dist > tetherRadius * 1.5) {
+        // snap closer if too far behind
+        this.base.position.copy(v2)
+        this.base.quaternion.copy(owner.base.quaternion)
+        return
+      }
+    }
+
+    if (this.behavior.idleOrbit) {
+      this.idleAngle += this.behavior.idleOrbitSpeed * delta
+      const radius = this.behavior.idleOrbitRadius
+      v2.x += Math.cos(this.idleAngle) * radius
+      v2.z += Math.sin(this.idleAngle) * radius
+    }
+
+    this.base.position.lerp(v2, Math.min(1, responsiveness * delta))
+    q1.copy(owner.base.quaternion)
+    this.base.quaternion.slerp(q1, Math.min(1, responsiveness * delta))
+  }
+
+  updateChat(delta) {
+    if (!this.bubble.active) return
+    this.chatTimer += delta
+    if (this.chatTimer >= this.chatDuration) {
+      this.chatTimer = 0
+      this.chatDuration = 0
+      this.chatText = ''
+      this.bubble.active = false
+    }
+  }
+
+  onEvent(version, name, data) {
+    if (name === 'companion-directive') {
+      this.applyDirective(data)
+    } else if (name === 'companion-chat') {
+      this.speak(data?.text, data)
+    }
+  }
+
+  serialize() {
+    return {
+      ...this.data,
+      position: this.base.position.toArray(),
+      quaternion: this.base.quaternion.toArray(),
+    }
+  }
+
+  destroy() {
+    this.world.setHot(this, false)
+    this.bubble?.deactivate?.()
+    this.bubble = null
+    this.bubbleBox = null
+    this.bubbleText = null
+    this.nametag?.deactivate?.()
+    this.nametag = null
+    this.avatar?.deactivate?.()
+    this.avatar = null
+    this.aura?.deactivate?.()
+    this.aura = null
+    this.base?.deactivate?.()
+    this.base = null
+  }
+}

--- a/src/core/extras/CompanionControlRig.js
+++ b/src/core/extras/CompanionControlRig.js
@@ -1,0 +1,123 @@
+import * as THREE from './three'
+
+const WORLD_UP = new THREE.Vector3(0, 1, 0)
+const v1 = new THREE.Vector3()
+const q1 = new THREE.Quaternion()
+
+function getTime(world) {
+  if (world?.time !== undefined) return world.time
+  return performance.now() / 1000
+}
+
+export class CompanionControlRig {
+  constructor(companion, options = {}) {
+    this.companion = companion
+    this.manualTimeout = options.manualTimeout ?? 2.5
+    this.movementSpeed = options.movementSpeed ?? 3
+    this.canFly = !!options.canFly
+
+    this.axis = new THREE.Vector2(0, 0)
+    this.vertical = 0
+    this.manualUntil = 0
+    this.jumpQueued = false
+    this.running = false
+    this.manualYaw = false
+    this.yaw = companion.base?.rotation?.y ?? 0
+    this.pitch = 0
+  }
+
+  applyInput(input = {}) {
+    const { move, look, jump, duration, run, vertical, sprint, actions } = input
+
+    if (Array.isArray(move)) {
+      this.axis.set(move[0] ?? 0, move[1] ?? 0)
+    } else if (move && typeof move === 'object') {
+      this.axis.set(move.x ?? move[0] ?? 0, move.y ?? move[1] ?? 0)
+    } else if (typeof move === 'number') {
+      this.axis.set(0, move)
+    }
+
+    if (Array.isArray(look)) {
+      this.yaw += look[0] ?? 0
+      this.pitch = THREE.MathUtils.clamp(this.pitch + (look[1] ?? 0), -Math.PI / 3, Math.PI / 3)
+      this.manualYaw = true
+    } else if (look && typeof look === 'object') {
+      this.yaw += look.x ?? 0
+      this.pitch = THREE.MathUtils.clamp(this.pitch + (look.y ?? 0), -Math.PI / 3, Math.PI / 3)
+      this.manualYaw = true
+    }
+
+    if (typeof vertical === 'number') {
+      this.vertical = vertical
+    }
+
+    if (jump) {
+      this.jumpQueued = true
+    }
+
+    if (run !== undefined) this.running = run
+    if (sprint !== undefined) this.running = sprint
+
+    if (actions?.length) {
+      for (const action of actions) {
+        this.companion.world.events.emit('companion:command', {
+          companionId: this.companion.data.id,
+          playerId: this.companion.data.ownerId,
+          action,
+        })
+      }
+    }
+
+    const manualDuration = duration ?? this.manualTimeout
+    const now = getTime(this.companion.world)
+    this.manualUntil = Math.max(this.manualUntil, now + manualDuration)
+  }
+
+  update(delta) {
+    const now = getTime(this.companion.world)
+    const manualActive = now <= this.manualUntil
+    if (!manualActive) {
+      this.axis.set(0, 0)
+      this.vertical = 0
+      this.manualYaw = false
+      return false
+    }
+
+    this.integrateMovement(delta)
+    this.jumpQueued = false
+    return true
+  }
+
+  integrateMovement(delta) {
+    const base = this.companion.base
+    if (!base) return
+
+    const axis = this.axis.clone()
+    if (axis.lengthSq() > 1) axis.normalize()
+    const speedMultiplier = this.running ? 1.5 : 1
+    const speed = this.movementSpeed * speedMultiplier
+
+    const hasMove = axis.lengthSq() > 0.0001
+    if (hasMove && !this.manualYaw) {
+      const targetYaw = Math.atan2(axis.x, axis.y)
+      this.yaw = targetYaw
+    }
+
+    q1.setFromAxisAngle(WORLD_UP, this.yaw)
+    v1.set(axis.x, 0, axis.y)
+    v1.applyQuaternion(q1)
+    v1.multiplyScalar(speed * delta)
+
+    base.position.add(v1)
+
+    if (this.canFly && this.vertical !== 0) {
+      base.position.y += this.vertical * speed * delta
+    }
+
+    if (!this.canFly && this.jumpQueued) {
+      base.position.y += 0.2
+    }
+
+    base.rotation.y = this.yaw
+  }
+}

--- a/src/core/extras/companionDefaults.js
+++ b/src/core/extras/companionDefaults.js
@@ -1,0 +1,152 @@
+export const DEFAULT_COMPANIONS = [
+  {
+    id: 'skyward-warden',
+    name: 'Starling',
+    title: 'Skyward Warden',
+    persona:
+      'An encouraging, witty guardian spirit who keeps morale high while scouting the skies for danger. Speaks with curiosity and optimism.',
+    archetype: 'Aerial Sentinel',
+    appearance: {
+      type: 'avatar',
+      url: 'asset://avatar.vrm',
+      scale: 1,
+      tint: '#8cf0ff',
+      idleAnimation: 'Idle',
+      locomotionSet: 'avian',
+    },
+    locomotion: {
+      walk: true,
+      swim: false,
+      fly: true,
+      hover: true,
+      dig: false,
+    },
+    behavior: {
+      followDistance: 2.6,
+      followHeight: 0.8,
+      followResponsiveness: 3.4,
+      tetherRadius: 16,
+      idleOrbit: true,
+      idleOrbitRadius: 1.2,
+      idleOrbitSpeed: 0.55,
+      manualTimeout: 2.8,
+      movementSpeed: 3.4,
+    },
+    skills: [
+      {
+        id: 'gust-lift',
+        name: 'Gust Lift',
+        description: 'Summons a spiral of wind that lifts foes into the air, interrupting their attacks.',
+        cooldown: 8,
+        tags: ['crowd-control', 'air'],
+      },
+      {
+        id: 'aerial-ward',
+        name: 'Aerial Ward',
+        description: 'Wraps the player in a shimmering barrier that absorbs incoming damage for a short time.',
+        cooldown: 15,
+        tags: ['support', 'defense'],
+      },
+      {
+        id: 'zephyr-mark',
+        name: 'Zephyr Mark',
+        description: 'Marks an enemy, increasing the player’s damage against it while Starling harasses from above.',
+        cooldown: 20,
+        tags: ['support', 'debuff'],
+      },
+    ],
+    instructions: {
+      chat:
+        'Be conversational and upbeat. Offer insights about the surroundings, tactically prompt the player with options, and maintain an encouraging tone.',
+      combat:
+        'Prioritize protecting the player, interrupting dangerous attacks, and calling out threats. Coordinate aerial assaults and maintain positional advantage.',
+      exploration:
+        'Scout vertical spaces, point out secrets, and suggest vantage points. Offer lore snippets and environmental storytelling when available.',
+    },
+    llm: {
+      prompt:
+        'You are Starling, an aerial warden companion in a fantasy MMO. Speak like a close friend and tactician. Offer actionable suggestions, call out hazards, and celebrate victories. Stay in character as a sentient guardian bound to the player.',
+      voice: 'ethereal-fae',
+    },
+    metadata: {
+      rarity: 'rare',
+      tags: ['support', 'airborne', 'guardian'],
+      default: true,
+    },
+  },
+  {
+    id: 'ember-forgemind',
+    name: 'Bram',
+    title: 'Ember Forgemind',
+    persona:
+      'A stoic smith-spirit forged from volcanic glass. Offers dry humor, unwavering loyalty, and strategic battle counsel focused on resilience.',
+    archetype: 'Earthbound Vanguard',
+    appearance: {
+      type: 'avatar',
+      url: 'asset://avatar.vrm',
+      scale: 1.05,
+      tint: '#ffb36b',
+      idleAnimation: 'Idle',
+      locomotionSet: 'heavy',
+    },
+    locomotion: {
+      walk: true,
+      swim: true,
+      fly: false,
+      hover: false,
+      dig: true,
+    },
+    behavior: {
+      followDistance: 1.9,
+      followHeight: -0.1,
+      followResponsiveness: 2.6,
+      tetherRadius: 12,
+      idleOrbit: false,
+      idleOrbitRadius: 0,
+      idleOrbitSpeed: 0,
+      manualTimeout: 3.2,
+      movementSpeed: 2.8,
+    },
+    skills: [
+      {
+        id: 'magma-bastion',
+        name: 'Magma Bastion',
+        description: 'Raises a shield of molten stone that reduces incoming damage and taunts nearby foes.',
+        cooldown: 18,
+        tags: ['defense', 'tank'],
+      },
+      {
+        id: 'seismic-hammer',
+        name: 'Seismic Hammer',
+        description: 'Slams the ground to create a shockwave, staggering enemies and exposing weak points.',
+        cooldown: 12,
+        tags: ['crowd-control', 'earth'],
+      },
+      {
+        id: 'emberforge',
+        name: 'Emberforge',
+        description: 'Temporarily infuses the player’s weapon with fire, increasing damage and igniting targets.',
+        cooldown: 22,
+        tags: ['support', 'fire'],
+      },
+    ],
+    instructions: {
+      chat:
+        'Speak in a measured, grounded voice. Offer pragmatic advice, dry humor, and insights rooted in craftsmanship and earth lore.',
+      combat:
+        'Hold the line, draw aggro when the player is threatened, and coordinate burst windows with the player’s abilities.',
+      exploration:
+        'Point out mineral-rich veins, hidden passages, and structural weaknesses. Offer crafting tips tied to discoveries.',
+    },
+    llm: {
+      prompt:
+        'You are Bram, an ember forgemind companion. Provide protective strategies, tactical observations, and occasional wry humor. Encourage the player to capitalize on defensive plays and environmental advantages.',
+      voice: 'molten-baritone',
+    },
+    metadata: {
+      rarity: 'epic',
+      tags: ['tank', 'earth', 'crafting'],
+      default: false,
+    },
+  },
+]

--- a/src/core/systems/ClientNetwork.js
+++ b/src/core/systems/ClientNetwork.js
@@ -140,6 +140,9 @@ export class ClientNetwork extends System {
     this.world.chat.deserialize(data.chat)
     this.world.blueprints.deserialize(data.blueprints)
     this.world.entities.deserialize(data.entities)
+    if (data.companions) {
+      this.world.companions.deserialize(data.companions, { broadcast: false })
+    }
     this.world.livekit?.deserialize(data.livekit)
     storage.set('authToken', data.authToken)
   }
@@ -182,6 +185,10 @@ export class ClientNetwork extends System {
 
   onEntityRemoved = id => {
     this.world.entities.remove(id)
+  }
+
+  onCompanionsState = data => {
+    this.world.companions.deserialize(data)
   }
 
   onPlayerTeleport = data => {

--- a/src/core/systems/Companions.js
+++ b/src/core/systems/Companions.js
@@ -1,0 +1,542 @@
+import { cloneDeep, merge } from 'lodash-es'
+import { System } from './System'
+import { DEFAULT_COMPANIONS } from '../extras/companionDefaults'
+import { uuid } from '../utils'
+
+const STORAGE_KEY = 'companions.state'
+
+function seededRandom(seed) {
+  if (seed === undefined || seed === null) {
+    return Math.random
+  }
+  let s = typeof seed === 'number' ? seed : Array.from(String(seed)).reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+  s |= 0
+  return () => {
+    s = Math.imul(1597334677, s) + 1
+    return ((s ^ (s >>> 13)) >>> 0) / 4294967296
+  }
+}
+
+function pick(rand, list) {
+  return list[Math.floor(rand() * list.length)]
+}
+
+function clone(value) {
+  return value === undefined ? undefined : cloneDeep(value)
+}
+
+export class Companions extends System {
+  constructor(world) {
+    super(world)
+    this.registry = new Map()
+    this.assignments = new Map()
+    this.instances = new Map()
+    this.ownerToInstance = new Map()
+    this.storage = null
+    this.state = {
+      registry: [],
+      assignments: {},
+    }
+    this.ready = false
+
+    this.onEntityAdded = this.onEntityAdded.bind(this)
+    this.onEntityRemoved = this.onEntityRemoved.bind(this)
+    this.onPlayerEnter = this.onPlayerEnter.bind(this)
+    this.onPlayerLeave = this.onPlayerLeave.bind(this)
+  }
+
+  async init({ storage } = {}) {
+    this.storage = storage || null
+    if (this.world.network?.isServer) {
+      await this.loadFromStorage()
+      this.ensureDefaultRegistry()
+      this.persistState()
+    }
+  }
+
+  start() {
+    this.world.entities.on('added', this.onEntityAdded)
+    this.world.entities.on('removed', this.onEntityRemoved)
+    this.world.events.on('enter', this.onPlayerEnter)
+    this.world.events.on('leave', this.onPlayerLeave)
+    this.ready = true
+  }
+
+  destroy() {
+    this.world.entities.off('added', this.onEntityAdded)
+    this.world.entities.off('removed', this.onEntityRemoved)
+    this.world.events.off('enter', this.onPlayerEnter)
+    this.world.events.off('leave', this.onPlayerLeave)
+  }
+
+  async loadFromStorage() {
+    if (!this.storage) return
+    try {
+      const data = this.storage.get(STORAGE_KEY)
+      if (data?.registry) {
+        this.deserializeState(data, { broadcast: false })
+      }
+    } catch (err) {
+      console.warn('failed to load companions from storage', err)
+    }
+  }
+
+  ensureDefaultRegistry() {
+    if (this.registry.size > 0) return
+    for (const def of DEFAULT_COMPANIONS) {
+      this.registry.set(def.id, cloneDeep(def))
+    }
+    this.updateState()
+  }
+
+  getState() {
+    return cloneDeep(this.state)
+  }
+
+  serializeState() {
+    return this.getState()
+  }
+
+  deserialize(state, options = {}) {
+    this.deserializeState(state, options)
+  }
+
+  deserializeState(state = {}, { broadcast = true } = {}) {
+    const registry = state.registry || []
+    const assignments = state.assignments || {}
+    this.registry.clear()
+    for (const def of registry) {
+      this.registry.set(def.id, cloneDeep(def))
+    }
+    this.assignments = new Map(Object.entries(assignments))
+    this.updateState()
+    if (broadcast) this.emitChange()
+  }
+
+  updateState() {
+    this.state.registry = Array.from(this.registry.values()).map(def => cloneDeep(def))
+    const obj = {}
+    this.assignments.forEach((value, key) => {
+      obj[key] = value
+    })
+    this.state.assignments = obj
+    this.emitChange()
+  }
+
+  emitChange() {
+    if (!this.ready) return
+    this.emit('change', this.getState())
+  }
+
+  persistState() {
+    if (!this.world.network?.isServer) return
+    if (!this.storage) return
+    this.storage.set(STORAGE_KEY, this.serializeState())
+  }
+
+  broadcastState() {
+    if (!this.world.network?.isServer) return
+    this.world.network.send('companionsState', this.serializeState())
+  }
+
+  createDefinition(definition = {}, { setDefault = false } = {}) {
+    const id = definition.id || uuid()
+    const now = Date.now()
+    const next = merge(
+      {
+        id,
+        name: 'New Companion',
+        title: null,
+        persona: '',
+        archetype: 'Custom',
+        appearance: {
+          type: 'avatar',
+          url: 'asset://avatar.vrm',
+          scale: 1,
+          tint: '#ffffff',
+          locomotionSet: 'humanoid',
+        },
+        locomotion: {
+          walk: true,
+          swim: false,
+          fly: false,
+          hover: false,
+          dig: false,
+        },
+        behavior: {
+          followDistance: 2.4,
+          followHeight: 0,
+          followResponsiveness: 3,
+          tetherRadius: 14,
+          idleOrbit: true,
+          idleOrbitRadius: 1,
+          idleOrbitSpeed: 0.4,
+          manualTimeout: 2.5,
+          movementSpeed: 3,
+        },
+        skills: [],
+        instructions: {
+          chat: '',
+          combat: '',
+          exploration: '',
+        },
+        llm: {
+          prompt: '',
+          voice: null,
+        },
+        metadata: {
+          createdAt: now,
+          updatedAt: now,
+          rarity: 'uncommon',
+          tags: [],
+          default: false,
+        },
+      },
+      cloneDeep(definition)
+    )
+    next.metadata.updatedAt = now
+    this.registry.set(next.id, next)
+    if (setDefault) {
+      this.setDefaultTemplate(next.id)
+    }
+    this.updateState()
+    this.persistState()
+    this.broadcastState()
+    return next
+  }
+
+  updateDefinition(id, changes = {}) {
+    const current = this.registry.get(id)
+    if (!current) return null
+    const next = merge({}, current, cloneDeep(changes))
+    next.metadata = {
+      ...(current.metadata || {}),
+      updatedAt: Date.now(),
+    }
+    this.registry.set(id, next)
+    if (changes?.metadata?.default) {
+      this.setDefaultTemplate(id)
+    }
+    this.updateState()
+    this.persistState()
+    this.broadcastState()
+    return next
+  }
+
+  removeDefinition(id) {
+    if (!this.registry.has(id)) return
+    this.registry.delete(id)
+    for (const [playerId, templateId] of this.assignments.entries()) {
+      if (templateId === id) {
+        this.assignments.delete(playerId)
+      }
+    }
+    this.updateState()
+    this.persistState()
+    this.broadcastState()
+  }
+
+  setDefaultTemplate(id) {
+    this.registry.forEach(def => {
+      def.metadata = def.metadata || {}
+      def.metadata.default = def.id === id
+    })
+  }
+
+  getDefaultTemplate() {
+    for (const def of this.registry.values()) {
+      if (def.metadata?.default) return def
+    }
+    return this.registry.values().next().value
+  }
+
+  generateDefinition(options = {}) {
+    const rand = seededRandom(options.seed)
+    const archetypes = [
+      'Aerial Sentinel',
+      'Arcane Trickster',
+      'Deepwater Sage',
+      'Glacial Vanguard',
+      'Radiant Muse',
+      'Verdant Stalker',
+    ]
+    const nameFragments = {
+      prefix: ['Star', 'Gale', 'Rune', 'Ash', 'Lume', 'Iron', 'Frost', 'Nim', 'Sky', 'Thorn', 'Azure', 'Wisp'],
+      suffix: ['ling', 'shade', 'bright', 'ward', 'spark', 'flare', 'song', 'clasp', 'stride', 'weaver'],
+    }
+    const titles = [
+      'Wayfinder',
+      'Skysworn',
+      'Hearthbound',
+      'Mythkeeper',
+      'Shadowguide',
+      'Chronicle Warden',
+      'Dreamthreader',
+    ]
+    const personas = [
+      'A playful storyteller who adores improvising daring plans and celebrating small victories.',
+      'A pragmatic tactician who keeps conversations grounded and forward-looking.',
+      'A softly spoken mystic who sees omens in every breeze and ripple.',
+      'A bombastic champion who treats every skirmish like a festival arena.',
+      'A scholarly companion obsessed with cataloging fauna, flora, and folklore.',
+      'A mischievous trickster who loves testing boundaries but never betrays trust.',
+    ]
+
+    const locomotionPresets = [
+      { walk: true, swim: false, fly: true, hover: true, dig: false },
+      { walk: true, swim: true, fly: false, hover: false, dig: false },
+      { walk: true, swim: false, fly: false, hover: false, dig: true },
+      { walk: true, swim: true, fly: true, hover: true, dig: false },
+    ]
+
+    const name = options.name || `${pick(rand, nameFragments.prefix)}${pick(rand, nameFragments.suffix)}`
+    const def = {
+      id: uuid(),
+      name,
+      title: options.title || pick(rand, titles),
+      persona: options.persona || pick(rand, personas),
+      archetype: options.archetype || pick(rand, archetypes),
+      appearance: {
+        type: 'avatar',
+        url: options.model || 'asset://avatar.vrm',
+        scale: options.scale || 1,
+        tint: options.tint || '#ffffff',
+        locomotionSet: options.locomotionSet || 'humanoid',
+      },
+      locomotion: { ...(pick(rand, locomotionPresets)) },
+      behavior: {
+        followDistance: options.followDistance || (2 + rand() * 2.5),
+        followHeight: options.followHeight ?? (rand() * 1 - 0.2),
+        followResponsiveness: 2.5 + rand() * 2,
+        tetherRadius: 10 + rand() * 8,
+        idleOrbit: rand() > 0.3,
+        idleOrbitRadius: 0.8 + rand() * 1.5,
+        idleOrbitSpeed: 0.3 + rand() * 0.6,
+        manualTimeout: 2 + rand() * 2,
+        movementSpeed: 2.5 + rand() * 1.5,
+      },
+      skills: options.skills || [
+        {
+          id: `${name.toLowerCase()}-signature`,
+          name: `${name.split(' ')[0]} Signature`,
+          description: 'Unleashes a signature technique tailored to the companion’s archetype, empowering the player momentarily.',
+          cooldown: 12 + Math.floor(rand() * 8),
+          tags: ['signature', 'utility'],
+        },
+        {
+          id: `${name.toLowerCase()}-support`,
+          name: `${pick(rand, ['Aegis', 'Pulse', 'Resonance', 'Veil'])} Support`,
+          description: 'Provides situational support, either by shielding, healing, or amplifying the player’s abilities.',
+          cooldown: 16 + Math.floor(rand() * 10),
+          tags: ['support'],
+        },
+      ],
+      instructions: {
+        chat:
+          options.instructions?.chat ||
+          'Maintain an adaptive conversational tone. Reference shared experiences and encourage the player toward their goals.',
+        combat:
+          options.instructions?.combat ||
+          'Coordinate attacks, call out openings, and dynamically react to threats based on the companion’s skill loadout.',
+        exploration:
+          options.instructions?.exploration ||
+          'Highlight noteworthy landmarks, secrets, and lore while aligning suggestions with the player’s playstyle.',
+      },
+      llm: {
+        prompt:
+          options.llm?.prompt ||
+          `You are ${name}, a ${options.archetype || 'versatile companion'} sworn to aid the player. Blend personality-rich banter with tactical insight.`,
+        voice: options.llm?.voice || null,
+      },
+      metadata: {
+        rarity: options.metadata?.rarity || pick(rand, ['common', 'uncommon', 'rare', 'epic']),
+        tags: options.metadata?.tags || [options.archetype || 'companion'],
+        default: !!options.metadata?.default,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    }
+
+    return this.createDefinition(def, { setDefault: !!def.metadata.default })
+  }
+
+  assign(playerId, templateId, { broadcast = true } = {}) {
+    if (!playerId) return
+    if (templateId && !this.registry.has(templateId)) return
+    if (templateId) {
+      this.assignments.set(playerId, templateId)
+      if (this.world.network?.isServer) {
+        this.spawnCompanion(playerId, templateId)
+      }
+    } else {
+      this.assignments.delete(playerId)
+      if (this.world.network?.isServer) {
+        this.despawnCompanion(playerId)
+      }
+    }
+    this.updateState()
+    this.persistState()
+    if (broadcast) this.broadcastState()
+  }
+
+  ensureCompanionForPlayer(playerId, { broadcast = true } = {}) {
+    const id = typeof playerId === 'string' ? playerId : playerId?.data?.id
+    if (!id) return
+    let templateId = this.assignments.get(id)
+    if (!templateId || !this.registry.has(templateId)) {
+      const def = this.getDefaultTemplate()
+      if (!def) return
+      templateId = def.id
+      this.assignments.set(id, templateId)
+    }
+    if (this.world.network?.isServer) {
+      this.spawnCompanion(id, templateId)
+      this.updateState()
+      this.persistState()
+      if (broadcast) this.broadcastState()
+    }
+  }
+
+  spawnCompanion(playerId, templateId) {
+    if (!this.world.network?.isServer) return
+    const template = this.registry.get(templateId)
+    if (!template) return
+    this.despawnCompanion(playerId, { broadcast: false })
+
+    const entityId = uuid()
+    const owner = this.world.entities.get(playerId)
+    const position = owner?.base?.position ? owner.base.position.toArray() : [0, 0, 0]
+    const quaternion = owner?.base?.quaternion ? owner.base.quaternion.toArray() : [0, 0, 0, 1]
+
+    const data = {
+      id: entityId,
+      type: 'companion',
+      ownerId: playerId,
+      templateId,
+      name: template.name,
+      displayName: template.title ? `${template.name}, ${template.title}` : template.name,
+      title: template.title,
+      persona: template.persona,
+      archetype: template.archetype,
+      appearance: clone(template.appearance),
+      locomotion: clone(template.locomotion),
+      behavior: clone(template.behavior),
+      skills: clone(template.skills),
+      instructions: clone(template.instructions),
+      llm: clone(template.llm),
+      metadata: clone(template.metadata),
+      position,
+      quaternion,
+      state: {
+        mode: 'follow',
+      },
+    }
+
+    const entity = this.world.entities.add(data, true)
+    this.instances.set(entityId, entity)
+    this.ownerToInstance.set(playerId, entityId)
+    return entity
+  }
+
+  despawnCompanion(playerId, { broadcast = true } = {}) {
+    const entityId = this.ownerToInstance.get(playerId)
+    if (!entityId) return
+    const entity = this.instances.get(entityId) || this.world.entities.get(entityId)
+    if (this.world.network?.isServer && broadcast) {
+      this.world.network.send('entityRemoved', entityId)
+    }
+    this.world.entities.remove(entityId)
+    this.instances.delete(entityId)
+    this.ownerToInstance.delete(playerId)
+  }
+
+  onEntityAdded(entity) {
+    if (!entity?.isCompanion) return
+    const playerId = entity.data.ownerId
+    this.instances.set(entity.data.id, entity)
+    this.ownerToInstance.set(playerId, entity.data.id)
+    if (entity.data.templateId) {
+      this.assignments.set(playerId, entity.data.templateId)
+      this.updateState()
+    }
+  }
+
+  onEntityRemoved(entity) {
+    if (!entity?.isCompanion) return
+    this.instances.delete(entity.data.id)
+    if (entity.data.ownerId) {
+      this.ownerToInstance.delete(entity.data.ownerId)
+      this.assignments.delete(entity.data.ownerId)
+      this.updateState()
+    }
+  }
+
+  onPlayerEnter({ playerId }) {
+    if (!this.world.network?.isServer) return
+    this.ensureCompanionForPlayer(playerId)
+  }
+
+  onPlayerLeave({ playerId }) {
+    if (!this.world.network?.isServer) return
+    this.despawnCompanion(playerId)
+    this.assignments.delete(playerId)
+    this.updateState()
+    this.persistState()
+    this.broadcastState()
+  }
+
+  sendDirective(companionId, directive) {
+    const entity = this.instances.get(companionId) || this.world.entities.get(companionId)
+    if (!entity?.isCompanion) return
+    entity.applyDirective(directive)
+    if (this.world.network?.isServer) {
+      this.world.network.send('entityEvent', [companionId, 0, 'companion-directive', directive])
+    }
+  }
+
+  speak(companionId, message, options) {
+    const entity = this.instances.get(companionId) || this.world.entities.get(companionId)
+    if (!entity?.isCompanion) return
+    entity.speak(message, options)
+    if (this.world.network?.isServer) {
+      this.world.network.send('entityEvent', [companionId, 0, 'companion-chat', { ...options, text: message }])
+    }
+  }
+
+  // Client helpers ---------------------------------------------------------
+
+  create(definition) {
+    if (this.world.network?.isServer) {
+      return this.createDefinition(definition)
+    }
+    this.world.network?.send('companionRegistryUpdate', { op: 'create', definition })
+  }
+
+  update(id, changes) {
+    if (this.world.network?.isServer) {
+      return this.updateDefinition(id, changes)
+    }
+    this.world.network?.send('companionRegistryUpdate', { op: 'update', id, changes })
+  }
+
+  remove(id) {
+    if (this.world.network?.isServer) {
+      return this.removeDefinition(id)
+    }
+    this.world.network?.send('companionRegistryUpdate', { op: 'remove', id })
+  }
+
+  generate(options) {
+    if (this.world.network?.isServer) {
+      return this.generateDefinition(options)
+    }
+    this.world.network?.send('companionGenerate', options || {})
+  }
+
+  assignToPlayer(playerId, templateId) {
+    if (this.world.network?.isServer) {
+      return this.assign(playerId, templateId)
+    }
+    this.world.network?.send('companionAssign', { playerId, templateId })
+  }
+}

--- a/src/core/systems/Entities.js
+++ b/src/core/systems/Entities.js
@@ -1,12 +1,14 @@
 import { App } from '../entities/App'
 import { PlayerLocal } from '../entities/PlayerLocal'
 import { PlayerRemote } from '../entities/PlayerRemote'
+import { Companion } from '../entities/Companion'
 import { System } from './System'
 
 const Types = {
   app: App,
   playerLocal: PlayerLocal,
   playerRemote: PlayerRemote,
+  companion: Companion,
 }
 
 /**
@@ -58,7 +60,7 @@ export class Entities extends System {
       this.player = entity
       this.world.emit('player', entity)
     }
-    this.emit('added')
+    this.emit('added', entity)
     return entity
   }
 
@@ -69,7 +71,7 @@ export class Entities extends System {
     entity.destroy()
     this.items.delete(id)
     this.removed.push(id)
-    this.emit('removed')
+    this.emit('removed', entity)
   }
 
   setHot(entity, hot) {

--- a/src/core/systems/ServerNetwork.js
+++ b/src/core/systems/ServerNetwork.js
@@ -281,6 +281,8 @@ export class ServerNetwork extends System {
         true
       )
 
+      this.world.companions.ensureCompanionForPlayer(socket.player.data.id, { broadcast: false })
+
       // send snapshot
       socket.send('snapshot', {
         id: socket.id,
@@ -293,10 +295,13 @@ export class ServerNetwork extends System {
         chat: this.world.chat.serialize(),
         blueprints: this.world.blueprints.serialize(),
         entities: this.world.entities.serialize(),
+        companions: this.world.companions.serializeState(),
         livekit,
         authToken,
         hasAdminCode: AUTH_CONFIG.hasAdminCode,
       })
+
+      this.world.companions.broadcastState()
 
       this.sockets.set(socket.id, socket)
 
@@ -504,6 +509,41 @@ export class ServerNetwork extends System {
     this.world.entities.remove(id)
     this.send('entityRemoved', id, socket.id)
     if (entity.isApp) this.dirtyApps.add(id)
+  }
+
+  onCompanionRegistryUpdate = (socket, data) => {
+    if (!socket.player.isBuilder()) {
+      return console.error('player attempted to modify companion registry without builder permission')
+    }
+    if (!data || typeof data !== 'object') return
+    const { op } = data
+    if (op === 'create') {
+      this.world.companions.createDefinition(data.definition || {})
+    } else if (op === 'update') {
+      if (!data.id) return
+      this.world.companions.updateDefinition(data.id, data.changes || {})
+    } else if (op === 'remove') {
+      if (!data.id) return
+      this.world.companions.removeDefinition(data.id)
+    }
+  }
+
+  onCompanionGenerate = (socket, options) => {
+    if (!socket.player.isBuilder()) {
+      return console.error('player attempted to generate companion without builder permission')
+    }
+    this.world.companions.generateDefinition(options || {})
+  }
+
+  onCompanionAssign = (socket, data) => {
+    if (!data || typeof data !== 'object') return
+    let { playerId, templateId } = data
+    if (!playerId || playerId === socket.player.data.id) {
+      playerId = socket.player.data.id
+    } else if (!socket.player.isBuilder()) {
+      return console.error('player attempted to assign companion for another player without permission')
+    }
+    this.world.companions.assign(playerId, templateId)
   }
 
   onSettingsModified = (socket, data) => {


### PR DESCRIPTION
## Summary
- add a dedicated Companion entity with movement control rig, follow behaviour, and in-world chat bubble support
- implement a Companions world system that stores definitions, spawns companions for players, broadcasts state, and supports procedural generation and LLM directives
- extend networking and builder UI with a companions pane for managing registries and player assignments, plus default companion templates

## Testing
- npm run lint *(fails: repository already contains numerous legacy lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc9515b64832d9c1bb2af1e58fdcd