### PR TITLE
Add scalable auction economy with companion-aware integration

### DIFF
--- a/src/core/World.js
+++ b/src/core/World.js
@@ -10,10 +10,12 @@ import { Events } from './systems/Events'
 import { Chat } from './systems/Chat'
 import { Blueprints } from './systems/Blueprints'
 import { Entities } from './systems/Entities'
+import { Economy } from './systems/Economy'
 import { Physics } from './systems/Physics'
 import { Stage } from './systems/Stage'
 import { Scripts } from './systems/Scripts'
 import { Companions } from './systems/Companions'
+import { Players } from './systems/Players'
 
 export class World extends EventEmitter {
   constructor() {
@@ -46,6 +48,8 @@ export class World extends EventEmitter {
     this.register('chat', Chat)
     this.register('blueprints', Blueprints)
     this.register('entities', Entities)
+    this.register('economy', Economy)
+    this.register('players', Players)
     this.register('companions', Companions)
     this.register('physics', Physics)
     this.register('stage', Stage)

--- a/src/core/systems/Companions.js
+++ b/src/core/systems/Companions.js
@@ -4,6 +4,50 @@ import { DEFAULT_COMPANIONS } from '../extras/companionDefaults'
 import { uuid } from '../utils'
 
 const STORAGE_KEY = 'companions.state'
+const MAX_COMPANION_SCALE = 5 / 8
+const COMMUNICATION_INTERVAL = 6
+const COMMUNICATION_RADIUS = 12
+const COMMUNICATION_SCAN_INTERVAL = 0.5
+
+function sanitizeAppearance(appearance = {}) {
+  const next = cloneDeep(appearance)
+  const currentScale = typeof next.scale === 'number' ? next.scale : MAX_COMPANION_SCALE
+  next.scale = Math.min(Math.max(currentScale, 0.1), MAX_COMPANION_SCALE)
+  if (typeof next.height === 'number') {
+    next.height = Math.min(next.height, MAX_COMPANION_SCALE * 2.2)
+  }
+  next.validation = {
+    ...(next.validation || {}),
+    maxScale: MAX_COMPANION_SCALE,
+    validatedAt: Date.now(),
+  }
+  return next
+}
+
+function enforceAppearance(definition) {
+  const before = definition.appearance?.scale
+  definition.appearance = sanitizeAppearance(definition.appearance || {})
+  const after = definition.appearance.scale
+  if (before !== after) {
+    definition.metadata = {
+      ...(definition.metadata || {}),
+      scaleAdjusted: true,
+      scaleValidatedAt: Date.now(),
+    }
+  } else {
+    definition.metadata = {
+      ...(definition.metadata || {}),
+      scaleValidatedAt: Date.now(),
+    }
+  }
+  return definition
+}
+
+function resolvePlayerName(world, playerId) {
+  if (!playerId) return 'their player'
+  const player = world.entities.get(playerId)
+  return player?.data?.displayName || player?.data?.name || playerId
+}
 
 function seededRandom(seed) {
   if (seed === undefined || seed === null) {
@@ -38,6 +82,8 @@ export class Companions extends System {
       assignments: {},
     }
     this.ready = false
+    this.communicationAccumulator = 0
+    this.communicationTracker = new Map()
 
     this.onEntityAdded = this.onEntityAdded.bind(this)
     this.onEntityRemoved = this.onEntityRemoved.bind(this)
@@ -84,7 +130,7 @@ export class Companions extends System {
   ensureDefaultRegistry() {
     if (this.registry.size > 0) return
     for (const def of DEFAULT_COMPANIONS) {
-      this.registry.set(def.id, cloneDeep(def))
+      this.registry.set(def.id, enforceAppearance(cloneDeep(def)))
     }
     this.updateState()
   }
@@ -106,7 +152,7 @@ export class Companions extends System {
     const assignments = state.assignments || {}
     this.registry.clear()
     for (const def of registry) {
-      this.registry.set(def.id, cloneDeep(def))
+      this.registry.set(def.id, enforceAppearance(cloneDeep(def)))
     }
     this.assignments = new Map(Object.entries(assignments))
     this.updateState()
@@ -152,7 +198,7 @@ export class Companions extends System {
         appearance: {
           type: 'avatar',
           url: 'asset://avatar.vrm',
-          scale: 1,
+          scale: MAX_COMPANION_SCALE,
           tint: '#ffffff',
           locomotionSet: 'humanoid',
         },
@@ -194,6 +240,7 @@ export class Companions extends System {
       },
       cloneDeep(definition)
     )
+    enforceAppearance(next)
     next.metadata.updatedAt = now
     this.registry.set(next.id, next)
     if (setDefault) {
@@ -213,6 +260,7 @@ export class Companions extends System {
       ...(current.metadata || {}),
       updatedAt: Date.now(),
     }
+    enforceAppearance(next)
     this.registry.set(id, next)
     if (changes?.metadata?.default) {
       this.setDefaultTemplate(id)
@@ -299,7 +347,7 @@ export class Companions extends System {
       appearance: {
         type: 'avatar',
         url: options.model || 'asset://avatar.vrm',
-        scale: options.scale || 1,
+        scale: Math.min(options.scale || MAX_COMPANION_SCALE, MAX_COMPANION_SCALE),
         tint: options.tint || '#ffffff',
         locomotionSet: options.locomotionSet || 'humanoid',
       },
@@ -357,6 +405,8 @@ export class Companions extends System {
       },
     }
 
+    enforceAppearance(def)
+
     return this.createDefinition(def, { setDefault: !!def.metadata.default })
   }
 
@@ -408,23 +458,25 @@ export class Companions extends System {
     const position = owner?.base?.position ? owner.base.position.toArray() : [0, 0, 0]
     const quaternion = owner?.base?.quaternion ? owner.base.quaternion.toArray() : [0, 0, 0, 1]
 
+    const sanitizedTemplate = enforceAppearance(cloneDeep(template))
+
     const data = {
       id: entityId,
       type: 'companion',
       ownerId: playerId,
       templateId,
-      name: template.name,
-      displayName: template.title ? `${template.name}, ${template.title}` : template.name,
-      title: template.title,
-      persona: template.persona,
-      archetype: template.archetype,
-      appearance: clone(template.appearance),
-      locomotion: clone(template.locomotion),
-      behavior: clone(template.behavior),
-      skills: clone(template.skills),
-      instructions: clone(template.instructions),
-      llm: clone(template.llm),
-      metadata: clone(template.metadata),
+      name: sanitizedTemplate.name,
+      displayName: sanitizedTemplate.title ? `${sanitizedTemplate.name}, ${sanitizedTemplate.title}` : sanitizedTemplate.name,
+      title: sanitizedTemplate.title,
+      persona: sanitizedTemplate.persona,
+      archetype: sanitizedTemplate.archetype,
+      appearance: clone(sanitizedTemplate.appearance),
+      locomotion: clone(sanitizedTemplate.locomotion),
+      behavior: clone(sanitizedTemplate.behavior),
+      skills: clone(sanitizedTemplate.skills),
+      instructions: clone(sanitizedTemplate.instructions),
+      llm: clone(sanitizedTemplate.llm),
+      metadata: clone(sanitizedTemplate.metadata),
       position,
       quaternion,
       state: {
@@ -435,6 +487,7 @@ export class Companions extends System {
     const entity = this.world.entities.add(data, true)
     this.instances.set(entityId, entity)
     this.ownerToInstance.set(playerId, entityId)
+    this.world.economy?.linkCompanion(entityId, playerId)
     return entity
   }
 
@@ -448,6 +501,7 @@ export class Companions extends System {
     this.world.entities.remove(entityId)
     this.instances.delete(entityId)
     this.ownerToInstance.delete(playerId)
+    this.world.economy?.unlinkCompanion(entityId)
   }
 
   onEntityAdded(entity) {
@@ -469,6 +523,7 @@ export class Companions extends System {
       this.assignments.delete(entity.data.ownerId)
       this.updateState()
     }
+    this.world.economy?.unlinkCompanion(entity.data.id)
   }
 
   onPlayerEnter({ playerId }) {
@@ -483,6 +538,63 @@ export class Companions extends System {
     this.updateState()
     this.persistState()
     this.broadcastState()
+  }
+
+  update(delta) {
+    if (!this.world.network?.isServer) return
+    if (this.instances.size < 2) return
+    this.communicationAccumulator += delta
+    if (this.communicationAccumulator < COMMUNICATION_SCAN_INTERVAL) return
+    this.communicationAccumulator = 0
+    const now = Date.now()
+    const companions = Array.from(this.instances.values())
+    for (let i = 0; i < companions.length; i++) {
+      const a = companions[i]
+      const posA = a?.base?.position
+      if (!posA?.distanceTo) continue
+      for (let j = i + 1; j < companions.length; j++) {
+        const b = companions[j]
+        const posB = b?.base?.position
+        if (!posB?.distanceTo) continue
+        const distance = posA.distanceTo(posB)
+        if (!Number.isFinite(distance) || distance > COMMUNICATION_RADIUS) continue
+        const key = a.data.id < b.data.id ? `${a.data.id}:${b.data.id}` : `${b.data.id}:${a.data.id}`
+        const last = this.communicationTracker.get(key) || 0
+        if (now - last < COMMUNICATION_INTERVAL * 1000) continue
+        this.communicationTracker.set(key, now)
+        this.initiateCompanionConversation(a, b, now, distance)
+      }
+    }
+  }
+
+  initiateCompanionConversation(companionA, companionB, timestamp, distance) {
+    const economy = this.world.economy
+    const ledgerA = economy?.getCompanionLedger(companionA.data.id)
+    const ledgerB = economy?.getCompanionLedger(companionB.data.id)
+    const currencyA = ledgerA?.currency
+    const currencyB = ledgerB?.currency
+    const describeCurrency = currency => {
+      if (!currency) return '0 Bytes and 0 Bits'
+      const byteLabel = currency.bytes === 1 ? 'Byte' : 'Bytes'
+      return `${currency.bytes} ${byteLabel} and ${currency.bits} Bits`
+    }
+    const ownerA = resolvePlayerName(this.world, companionA.data.ownerId)
+    const ownerB = resolvePlayerName(this.world, companionB.data.ownerId)
+    const messageA = `Signal check, ${companionB.data.name}. Guarding ${describeCurrency(currencyA)} for ${ownerA}.`
+    const messageB = `Acknowledged, ${companionA.data.name}. ${ownerB} trusts me with ${describeCurrency(currencyB)}. Bits ready.`
+
+    this.speak(companionA.data.id, messageA)
+    this.speak(companionB.data.id, messageB)
+
+    const payload = {
+      from: companionA.data.id,
+      to: companionB.data.id,
+      at: timestamp,
+      distance,
+      owners: [companionA.data.ownerId, companionB.data.ownerId],
+    }
+    this.emit('proximity:chat', payload)
+    this.world.events.emit('companion:proximity-chat', payload)
   }
 
   sendDirective(companionId, directive) {

--- a/src/core/systems/Economy.js
+++ b/src/core/systems/Economy.js
@@ -1,0 +1,606 @@
+import { cloneDeep } from 'lodash-es'
+import { System } from './System'
+import { uuid } from '../utils'
+
+const STORAGE_KEY = 'economy.state'
+const BIT_PER_BYTE = 100
+const TRANSACTION_HISTORY_LIMIT = 64
+
+class TransactionLog {
+  constructor(limit = TRANSACTION_HISTORY_LIMIT) {
+    this.limit = limit
+    this.items = new Array(limit)
+    this.head = 0
+    this.count = 0
+  }
+
+  record(entry) {
+    this.items[this.head] = entry
+    this.head = (this.head + 1) % this.limit
+    if (this.count < this.limit) {
+      this.count++
+    }
+  }
+
+  toArray() {
+    const result = []
+    for (let i = 0; i < this.count; i++) {
+      const index = (this.head - this.count + i + this.limit) % this.limit
+      result.push(this.items[index])
+    }
+    return result
+  }
+
+  static from(data) {
+    const log = new TransactionLog(data?.limit || TRANSACTION_HISTORY_LIMIT)
+    const entries = Array.isArray(data?.items) ? data.items : []
+    const count = Math.min(entries.length, log.limit)
+    const start = Math.max(entries.length - count, 0)
+    for (let i = start; i < entries.length; i++) {
+      log.record(entries[i])
+    }
+    return log
+  }
+}
+
+function normalizeCurrency({ bytes = 0, bits = 0 } = {}) {
+  const major = Math.trunc(bytes)
+  const minor = Math.trunc(bits)
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) {
+    throw new Error('invalid currency value')
+  }
+  let totalBits = major * BIT_PER_BYTE + minor
+  if (!Number.isFinite(totalBits)) throw new Error('invalid currency value')
+  if (totalBits < 0) totalBits = 0
+  const normalizedBytes = Math.floor(totalBits / BIT_PER_BYTE)
+  const normalizedBits = totalBits % BIT_PER_BYTE
+  return { bytes: normalizedBytes, bits: normalizedBits }
+}
+
+function addCurrency(a, b) {
+  return normalizeCurrency({ bytes: a.bytes + b.bytes, bits: a.bits + b.bits })
+}
+
+function subtractCurrency(a, b) {
+  let totalBitsA = a.bytes * BIT_PER_BYTE + a.bits
+  const totalBitsB = b.bytes * BIT_PER_BYTE + b.bits
+  totalBitsA -= totalBitsB
+  if (totalBitsA < 0) throw new Error('insufficient funds')
+  const bytes = Math.floor(totalBitsA / BIT_PER_BYTE)
+  const bits = totalBitsA % BIT_PER_BYTE
+  return { bytes, bits }
+}
+
+function hasCurrency(a, b) {
+  const totalBitsA = a.bytes * BIT_PER_BYTE + a.bits
+  const totalBitsB = b.bytes * BIT_PER_BYTE + b.bits
+  return totalBitsA >= totalBitsB
+}
+
+function shallowClone(value) {
+  return value == null ? value : cloneDeep(value)
+}
+
+function createListingSnapshot(listing) {
+  return {
+    id: listing.id,
+    item: shallowClone(listing.item),
+    price: normalizeCurrency(listing.price),
+    sellerId: listing.sellerId,
+    buyerId: listing.buyerId || null,
+    status: listing.status,
+    createdAt: listing.createdAt,
+    updatedAt: listing.updatedAt,
+    soldAt: listing.soldAt || null,
+  }
+}
+
+export class Economy extends System {
+  constructor(world) {
+    super(world)
+    this.storage = null
+    this.players = new Map()
+    this.auctions = new Map()
+    this.playerListings = new Map()
+    this.categoryIndex = new Map()
+    this.listingLocks = new Set()
+    this.transactionLogs = new Map()
+    this.companionToPlayer = new Map()
+    this.playerToCompanions = new Map()
+    this.currency = {
+      major: {
+        name: 'Byte',
+        symbol: 'Ɓ',
+        unit: 'byte',
+        model: 'asset://economy/byte-diamond.glb',
+        description: 'A byte gemstone representing 100 bits of value.',
+      },
+      minor: {
+        name: 'Bit',
+        symbol: 'ƀ',
+        unit: 'bit',
+        model: 'asset://economy/bit-diamond.glb',
+        description: 'A bit gemstone representing 1/100th of a byte.',
+      },
+      ratio: BIT_PER_BYTE,
+    }
+
+    this.onPlayerEnter = this.onPlayerEnter.bind(this)
+    this.onPlayerLeave = this.onPlayerLeave.bind(this)
+  }
+
+  async init({ storage } = {}) {
+    this.storage = storage || null
+    if (this.world.network?.isServer) {
+      await this.loadFromStorage()
+    }
+  }
+
+  start() {
+    this.world.events.on('enter', this.onPlayerEnter)
+    this.world.events.on('leave', this.onPlayerLeave)
+  }
+
+  destroy() {
+    this.world.events.off('enter', this.onPlayerEnter)
+    this.world.events.off('leave', this.onPlayerLeave)
+  }
+
+  async loadFromStorage() {
+    if (!this.storage) return
+    try {
+      const data = this.storage.get(STORAGE_KEY)
+      if (!data) return
+      this.deserializeState(data)
+    } catch (err) {
+      console.warn('failed to load economy state', err)
+    }
+  }
+
+  persistState() {
+    if (!this.world.network?.isServer) return
+    if (!this.storage) return
+    this.storage.set(STORAGE_KEY, this.serializeState())
+  }
+
+  serializeState() {
+    const players = {}
+    this.players.forEach((ledger, playerId) => {
+      players[playerId] = {
+        currency: normalizeCurrency(ledger.currency),
+        inventory: Array.from(ledger.inventory.values()).map(item => shallowClone(item)),
+        listings: Array.from(ledger.listings),
+        transactions: {
+          limit: ledger.transactions.limit,
+          items: ledger.transactions.toArray(),
+        },
+      }
+    })
+    const auctions = Array.from(this.auctions.values()).map(listing => ({
+      id: listing.id,
+      item: shallowClone(listing.item),
+      price: normalizeCurrency(listing.price),
+      sellerId: listing.sellerId,
+      buyerId: listing.buyerId || null,
+      status: listing.status,
+      createdAt: listing.createdAt,
+      updatedAt: listing.updatedAt,
+      soldAt: listing.soldAt || null,
+      category: listing.category,
+    }))
+    return { players, auctions }
+  }
+
+  deserializeState(state = {}) {
+    const players = state.players || {}
+    this.players.clear()
+    this.playerListings.clear()
+    this.transactionLogs.clear()
+    Object.entries(players).forEach(([playerId, data]) => {
+      const ledger = this.createEmptyLedger()
+      ledger.currency = normalizeCurrency(data.currency || {})
+      const inventoryItems = Array.isArray(data.inventory) ? data.inventory : []
+      inventoryItems.forEach(item => {
+        ledger.inventory.set(item.id, shallowClone(item))
+      })
+      const listings = Array.isArray(data.listings) ? data.listings : []
+      ledger.listings = new Set(listings)
+      ledger.transactions = TransactionLog.from(data.transactions)
+      this.players.set(playerId, ledger)
+      if (listings.length) {
+        this.playerListings.set(playerId, new Set(listings))
+      }
+      this.transactionLogs.set(playerId, ledger.transactions)
+    })
+
+    this.auctions.clear()
+    this.categoryIndex.clear()
+    const auctions = Array.isArray(state.auctions) ? state.auctions : []
+    auctions.forEach(raw => {
+      const listing = {
+        id: raw.id,
+        item: shallowClone(raw.item),
+        price: normalizeCurrency(raw.price),
+        sellerId: raw.sellerId,
+        buyerId: raw.buyerId || null,
+        status: raw.status || 'listed',
+        createdAt: raw.createdAt,
+        updatedAt: raw.updatedAt || raw.createdAt,
+        soldAt: raw.soldAt || null,
+        category: raw.category || raw.item?.type || 'general',
+      }
+      this.auctions.set(listing.id, listing)
+      this.indexListing(listing)
+      this.addListingToSeller(listing.sellerId, listing.id)
+    })
+  }
+
+  createEmptyLedger() {
+    return {
+      currency: { bytes: 0, bits: 0 },
+      inventory: new Map(),
+      listings: new Set(),
+      transactions: new TransactionLog(),
+    }
+  }
+
+  ensurePlayerLedger(playerId) {
+    if (!playerId) return null
+    if (!this.players.has(playerId)) {
+      const ledger = this.createEmptyLedger()
+      this.players.set(playerId, ledger)
+      this.transactionLogs.set(playerId, ledger.transactions)
+    }
+    if (!this.playerListings.has(playerId)) {
+      this.playerListings.set(playerId, new Set())
+    }
+    return this.players.get(playerId)
+  }
+
+  onPlayerEnter({ playerId }) {
+    const ledger = this.ensurePlayerLedger(playerId)
+    if (!ledger) return
+    if (ledger.transactions.count === 0) {
+      this.recordTransaction(playerId, {
+        id: uuid(),
+        type: 'system:init',
+        at: Date.now(),
+        summary: 'Ledger initialized',
+      })
+    }
+  }
+
+  onPlayerLeave({ playerId }) {
+    const ledger = this.players.get(playerId)
+    if (!ledger) return
+    this.recordTransaction(playerId, {
+      id: uuid(),
+      type: 'system:leave',
+      at: Date.now(),
+      summary: 'Player left world',
+    })
+  }
+
+  getCurrencyMetadata() {
+    return cloneDeep(this.currency)
+  }
+
+  getPlayerSnapshot(playerId) {
+    const ledger = this.players.get(playerId)
+    if (!ledger) return null
+    return {
+      playerId,
+      currency: normalizeCurrency(ledger.currency),
+      inventory: Array.from(ledger.inventory.values()).map(item => shallowClone(item)),
+      listings: Array.from(ledger.listings),
+      transactions: ledger.transactions.toArray(),
+    }
+  }
+
+  getInventory(playerId) {
+    const ledger = this.ensurePlayerLedger(playerId)
+    if (!ledger) return []
+    return Array.from(ledger.inventory.values()).map(item => shallowClone(item))
+  }
+
+  addToInventory(playerId, item) {
+    const ledger = this.ensurePlayerLedger(playerId)
+    if (!ledger) throw new Error('missing player ledger')
+    const id = item.id || uuid()
+    const entry = { ...shallowClone(item), id }
+    ledger.inventory.set(id, entry)
+    this.recordTransaction(playerId, {
+      id: uuid(),
+      type: 'inventory:add',
+      at: Date.now(),
+      item: shallowClone(entry),
+      summary: `Added ${entry.type || 'item'} ${entry.name || entry.id} to inventory`,
+    })
+    this.persistState()
+    return entry
+  }
+
+  removeFromInventory(playerId, itemId) {
+    const ledger = this.ensurePlayerLedger(playerId)
+    if (!ledger) throw new Error('missing player ledger')
+    const entry = ledger.inventory.get(itemId)
+    if (!entry) return null
+    ledger.inventory.delete(itemId)
+    this.recordTransaction(playerId, {
+      id: uuid(),
+      type: 'inventory:remove',
+      at: Date.now(),
+      item: shallowClone(entry),
+      summary: `Removed ${entry.type || 'item'} ${entry.name || entry.id} from inventory`,
+    })
+    this.persistState()
+    return entry
+  }
+
+  credit(playerId, value, context = {}) {
+    const ledger = this.ensurePlayerLedger(playerId)
+    if (!ledger) throw new Error('missing player ledger')
+    const amount = normalizeCurrency(value)
+    ledger.currency = addCurrency(ledger.currency, amount)
+    this.recordTransaction(playerId, {
+      id: uuid(),
+      type: 'currency:credit',
+      at: Date.now(),
+      amount,
+      context,
+      summary: `Received ${amount.bytes} Bytes and ${amount.bits} Bits`,
+    })
+    this.persistState()
+    return ledger.currency
+  }
+
+  debit(playerId, value, context = {}) {
+    const ledger = this.ensurePlayerLedger(playerId)
+    if (!ledger) throw new Error('missing player ledger')
+    const amount = normalizeCurrency(value)
+    if (!hasCurrency(ledger.currency, amount)) {
+      throw new Error('insufficient funds')
+    }
+    ledger.currency = subtractCurrency(ledger.currency, amount)
+    this.recordTransaction(playerId, {
+      id: uuid(),
+      type: 'currency:debit',
+      at: Date.now(),
+      amount,
+      context,
+      summary: `Spent ${amount.bytes} Bytes and ${amount.bits} Bits`,
+    })
+    this.persistState()
+    return ledger.currency
+  }
+
+  recordTransaction(playerId, entry) {
+    const ledger = this.ensurePlayerLedger(playerId)
+    if (!ledger) return
+    ledger.transactions.record(entry)
+    this.transactionLogs.set(playerId, ledger.transactions)
+    const event = { playerId, entry }
+    this.emit('transaction', event)
+    this.world.events.emit('economy:transaction', event)
+  }
+
+  listItem(playerId, itemId, price, { category, metadata } = {}) {
+    const ledger = this.ensurePlayerLedger(playerId)
+    if (!ledger) throw new Error('missing player ledger')
+    const normalizedPrice = normalizeCurrency(price)
+    const item = ledger.inventory.get(itemId)
+    if (!item) throw new Error('item not found in inventory')
+    ledger.inventory.delete(itemId)
+    const listing = {
+      id: uuid(),
+      item: shallowClone(item),
+      price: normalizedPrice,
+      sellerId: playerId,
+      buyerId: null,
+      status: 'listed',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      category: category || item.type || 'general',
+      metadata: metadata ? shallowClone(metadata) : undefined,
+    }
+    this.auctions.set(listing.id, listing)
+    ledger.listings.add(listing.id)
+    this.addListingToSeller(playerId, listing.id)
+    this.indexListing(listing)
+    this.recordTransaction(playerId, {
+      id: uuid(),
+      type: 'auction:list',
+      at: Date.now(),
+      listingId: listing.id,
+      price: normalizedPrice,
+      item: shallowClone(item),
+      summary: `Listed ${item.type || 'item'} ${item.name || item.id} for auction`,
+    })
+    this.persistState()
+    const snapshot = createListingSnapshot(listing)
+    this.emit('auction:list', snapshot)
+    this.world.events.emit('economy:auction:list', snapshot)
+    return snapshot
+  }
+
+  cancelListing(playerId, listingId) {
+    const listing = this.auctions.get(listingId)
+    if (!listing) return null
+    if (listing.sellerId !== playerId) throw new Error('cannot cancel another players listing')
+    if (listing.status !== 'listed') throw new Error('listing not active')
+    this.unlockListing(listingId)
+    this.auctions.delete(listingId)
+    this.removeListingFromSeller(playerId, listingId)
+    const ledger = this.ensurePlayerLedger(playerId)
+    if (ledger) {
+      ledger.listings.delete(listingId)
+      ledger.inventory.set(listing.item.id, shallowClone(listing.item))
+      this.recordTransaction(playerId, {
+        id: uuid(),
+        type: 'auction:cancel',
+        at: Date.now(),
+        listingId,
+        item: shallowClone(listing.item),
+        summary: `Cancelled listing ${listing.item.name || listing.item.id}`,
+      })
+    }
+    this.unindexListing(listing)
+    this.persistState()
+    const snapshot = createListingSnapshot(listing)
+    snapshot.status = 'cancelled'
+    this.emit('auction:cancel', snapshot)
+    this.world.events.emit('economy:auction:cancel', snapshot)
+    return snapshot
+  }
+
+  purchaseListing(listingId, buyerId) {
+    const listing = this.auctions.get(listingId)
+    if (!listing) throw new Error('listing not found')
+    if (listing.status !== 'listed') throw new Error('listing not available')
+    if (!this.tryLockListing(listingId)) {
+      throw new Error('listing locked')
+    }
+    try {
+      const buyerLedger = this.ensurePlayerLedger(buyerId)
+      if (!buyerLedger) throw new Error('missing buyer ledger')
+      if (!hasCurrency(buyerLedger.currency, listing.price)) {
+        throw new Error('buyer has insufficient funds')
+      }
+      const sellerLedger = this.ensurePlayerLedger(listing.sellerId)
+      if (!sellerLedger) throw new Error('missing seller ledger')
+      buyerLedger.currency = subtractCurrency(buyerLedger.currency, listing.price)
+      sellerLedger.currency = addCurrency(sellerLedger.currency, listing.price)
+      buyerLedger.inventory.set(listing.item.id, shallowClone(listing.item))
+      sellerLedger.listings.delete(listing.id)
+      this.removeListingFromSeller(listing.sellerId, listing.id)
+      listing.status = 'sold'
+      listing.buyerId = buyerId
+      listing.updatedAt = Date.now()
+      listing.soldAt = listing.updatedAt
+      this.auctions.delete(listingId)
+      this.unindexListing(listing)
+
+      const buyerContext = {
+        listingId,
+        sellerId: listing.sellerId,
+        item: shallowClone(listing.item),
+      }
+      const sellerContext = {
+        listingId,
+        buyerId,
+        item: shallowClone(listing.item),
+      }
+      this.recordTransaction(buyerId, {
+        id: uuid(),
+        type: 'auction:purchase',
+        at: listing.updatedAt,
+        amount: normalizeCurrency(listing.price),
+        context: buyerContext,
+        summary: `Purchased ${listing.item.name || listing.item.id}`,
+      })
+      this.recordTransaction(listing.sellerId, {
+        id: uuid(),
+        type: 'auction:sale',
+        at: listing.updatedAt,
+        amount: normalizeCurrency(listing.price),
+        context: sellerContext,
+        summary: `Sold ${listing.item.name || listing.item.id}`,
+      })
+      this.persistState()
+      const snapshot = createListingSnapshot(listing)
+      this.emit('auction:sold', snapshot)
+      this.world.events.emit('economy:auction:sold', snapshot)
+      return snapshot
+    } finally {
+      this.unlockListing(listingId)
+    }
+  }
+
+  tryLockListing(listingId) {
+    if (this.listingLocks.has(listingId)) return false
+    this.listingLocks.add(listingId)
+    return true
+  }
+
+  unlockListing(listingId) {
+    this.listingLocks.delete(listingId)
+  }
+
+  indexListing(listing) {
+    const category = listing.category || listing.item?.type || 'general'
+    if (!this.categoryIndex.has(category)) {
+      this.categoryIndex.set(category, new Set())
+    }
+    this.categoryIndex.get(category).add(listing.id)
+  }
+
+  unindexListing(listing) {
+    const category = listing.category || listing.item?.type || 'general'
+    const index = this.categoryIndex.get(category)
+    if (index) {
+      index.delete(listing.id)
+      if (index.size === 0) {
+        this.categoryIndex.delete(category)
+      }
+    }
+  }
+
+  addListingToSeller(playerId, listingId) {
+    if (!this.playerListings.has(playerId)) {
+      this.playerListings.set(playerId, new Set())
+    }
+    this.playerListings.get(playerId).add(listingId)
+  }
+
+  removeListingFromSeller(playerId, listingId) {
+    const set = this.playerListings.get(playerId)
+    if (!set) return
+    set.delete(listingId)
+    if (set.size === 0) {
+      this.playerListings.delete(playerId)
+    }
+  }
+
+  getListings({ category } = {}) {
+    if (!category) {
+      return Array.from(this.auctions.values()).map(listing => createListingSnapshot(listing))
+    }
+    const set = this.categoryIndex.get(category)
+    if (!set) return []
+    const result = []
+    set.forEach(id => {
+      const listing = this.auctions.get(id)
+      if (listing) {
+        result.push(createListingSnapshot(listing))
+      }
+    })
+    return result
+  }
+
+  linkCompanion(companionId, playerId) {
+    if (!companionId || !playerId) return
+    this.ensurePlayerLedger(playerId)
+    this.companionToPlayer.set(companionId, playerId)
+    if (!this.playerToCompanions.has(playerId)) {
+      this.playerToCompanions.set(playerId, new Set())
+    }
+    this.playerToCompanions.get(playerId).add(companionId)
+  }
+
+  unlinkCompanion(companionId) {
+    const playerId = this.companionToPlayer.get(companionId)
+    if (!playerId) return
+    this.companionToPlayer.delete(companionId)
+    const set = this.playerToCompanions.get(playerId)
+    if (set) {
+      set.delete(companionId)
+      if (set.size === 0) this.playerToCompanions.delete(playerId)
+    }
+  }
+
+  getCompanionLedger(companionId) {
+    const playerId = this.companionToPlayer.get(companionId)
+    if (!playerId) return null
+    return this.getPlayerSnapshot(playerId)
+  }
+}

--- a/src/core/systems/Players.js
+++ b/src/core/systems/Players.js
@@ -1,0 +1,82 @@
+import { System } from './System'
+import { uuid } from '../utils'
+
+export class Players extends System {
+  constructor(world) {
+    super(world)
+    this.players = new Map()
+    this.onEnter = this.onEnter.bind(this)
+    this.onLeave = this.onLeave.bind(this)
+  }
+
+  start() {
+    this.world.events.on('enter', this.onEnter)
+    this.world.events.on('leave', this.onLeave)
+  }
+
+  destroy() {
+    this.world.events.off('enter', this.onEnter)
+    this.world.events.off('leave', this.onLeave)
+    this.players.clear()
+  }
+
+  onEnter({ playerId }) {
+    if (!playerId) return
+    if (!this.players.has(playerId)) {
+      this.players.set(playerId, { id: playerId, joinedAt: Date.now(), sessionId: uuid() })
+    }
+    this.world.economy?.ensurePlayerLedger(playerId)
+  }
+
+  onLeave({ playerId }) {
+    if (!playerId) return
+    const record = this.players.get(playerId)
+    if (record) {
+      record.leftAt = Date.now()
+    }
+  }
+
+  get(playerId) {
+    return this.players.get(playerId) || null
+  }
+
+  getCurrency(playerId) {
+    return this.world.economy?.getPlayerSnapshot(playerId)?.currency || null
+  }
+
+  getInventory(playerId) {
+    return this.world.economy?.getInventory(playerId) || []
+  }
+
+  getTransactions(playerId) {
+    return this.world.economy?.getPlayerSnapshot(playerId)?.transactions || []
+  }
+
+  credit(playerId, amount, context) {
+    return this.world.economy?.credit(playerId, amount, context)
+  }
+
+  debit(playerId, amount, context) {
+    return this.world.economy?.debit(playerId, amount, context)
+  }
+
+  addToInventory(playerId, item) {
+    return this.world.economy?.addToInventory(playerId, item)
+  }
+
+  removeFromInventory(playerId, itemId) {
+    return this.world.economy?.removeFromInventory(playerId, itemId)
+  }
+
+  listItem(playerId, itemId, price, options) {
+    return this.world.economy?.listItem(playerId, itemId, price, options)
+  }
+
+  cancelListing(playerId, listingId) {
+    return this.world.economy?.cancelListing(playerId, listingId)
+  }
+
+  purchase(listingId, buyerId) {
+    return this.world.economy?.purchaseListing(listingId, buyerId)
+  }
+}


### PR DESCRIPTION
## Summary
- introduce an Economy system that tracks Bits/Bytes currency, O(1) ledgers, and atomic auction listings backed directly by player inventories
- add a Players system that exposes ledger, inventory, and listing helpers to other systems and register both players and companions against the shared economy
- enforce companion scale limits, hook companions into the economy, and add proximity chat for autonomous companion coordination

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ebd08d4310832d82845d56f49b4303