### PR TITLE
Add MMORPG readiness roadmap documentation

### DIFF
--- a/docs/mmorpg-roadmap.md
+++ b/docs/mmorpg-roadmap.md
@@ -1,0 +1,39 @@
+# MMORPG Readiness Roadmap
+
+This document outlines concrete engineering initiatives that would move Hyperfy from a shared virtual world framework toward a production-ready MMORPG platform.
+
+## 1. Infrastructure & Scale
+
+- **Authoritative multi-zone servers** – Replace the single Fastify process that currently boots one world instance with a topology of authoritative game servers, shard managers, and load-balanced gateways. Each zone server should own simulation authority, coordinate transfers, and expose metrics for orchestration.【F:src/server/index.js†L5-L200】【F:src/core/createServerWorld.js†L1-L18】
+- **Realtime networking upgrades** – Extend `ServerNetwork` with replication throttling, prioritised interest management, and configurable tick rates per zone so updates scale with population instead of broadcasting every packet to all sockets.【F:src/core/systems/ServerNetwork.js†L84-L124】【F:src/core/systems/Server.js†L3-L30】
+- **Resilience & observability** – Introduce health probes, autoscaling signals, and crash recovery for each service. Capture structured telemetry for tick time, bandwidth, and error rates to feed capacity planning and incident response.【F:src/server/index.js†L139-L181】
+
+## 2. Persistence & Progression
+
+- **Character services** – The current persistence layer only hydrates world blueprints and entity definitions. Add services and schemas for player profiles, inventories, achievements, and quest states with transactional guarantees and migrations.【F:src/core/systems/ServerNetwork.js†L46-L188】
+- **Economic systems** – Implement secure wallet/account balances, crafting, and trading subsystems with anti-duplication measures, rate limiting, and audit trails.
+- **Account security** – Integrate modern auth (e.g., OAuth/OIDC), device fingerprinting, and anti-cheat heuristics ahead of cross-server transfers.【F:src/server/index.js†L158-L175】
+
+## 3. Gameplay & Social Systems
+
+- **Combat & abilities** – Build authoritative combat resolvers, cooldown management, and effect pipelines with deterministic rollback, rather than trusting client-reported actions.
+- **Quest & narrative tools** – Provide designers with node-based quest editors and live scripting hooks (building on the existing app system) so narrative content can ship rapidly.【F:README.md†L12-L99】
+- **Social layers** – Expand chat, guilds, parties, and matchmaking using scalable messaging backends, plus moderation workflows for reports, muting, and ban appeals.
+
+## 4. World Building & Content Pipeline
+
+- **Asset ingestion pipeline** – Automate LOD baking, navmesh generation, and asset validation instead of manual uploads through the current hashed asset serving flow.【F:src/server/index.js†L110-L137】
+- **Live operations tooling** – Extend the in-world builder into a full CMS for events, seasonal updates, and A/B testing with instant rollback capabilities.
+- **Testing automation** – Grow the existing headless agent into a suite of scripted performance and regression bots to guard against content and gameplay regressions.【F:README.md†L53-L89】
+
+## 5. Client, Rendering & UX
+
+- **High-fidelity renderer** – Augment the WebGL renderer with WebGPU or native clients to unlock large crowds, advanced lighting, and platform-specific optimisations beyond the current AO/bloom stack.【F:src/core/systems/ClientGraphics.js†L1-L200】【F:docs/DEPLOYMENT_STATUS.md†L15-L35】
+- **Input & accessibility** – Layer on action combat controls, controller support, remappable keybinds, and accessibility features (UI scaling, color blindness filters) for broad audiences.
+- **Performance budgets** – Enforce strict per-frame budgets through frame graph instrumentation, asset streaming hints, and fallback quality tiers for low-end devices.
+
+## 6. DevOps & Compliance
+
+- **Continuous delivery** – Stand up CI/CD that lint, test, build, and package every service; publish container images and infrastructure-as-code modules for repeatable deployment.【F:README.md†L118-L142】
+- **Monitoring & support** – Integrate paging, log aggregation, and customer support tooling so live operations teams can respond quickly to incidents.
+- **Legal & data protection** – Implement GDPR/CCPA-compliant data retention, parental controls, and incident response plans suitable for a global MMORPG audience.


### PR DESCRIPTION
## Summary
- add a roadmap document that outlines engineering initiatives required to evolve Hyperfy into a production-ready MMORPG platform

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebdc6d4320832db5a16a2ce1ebeb26