### PR TITLE
Add multi-zone server scaffolding and observability endpoints

### DIFF
--- a/docs/mmorpg-roadmap.md
+++ b/docs/mmorpg-roadmap.md
@@ -5,6 +5,7 @@ This document outlines concrete engineering initiatives that would move Hyperfy 
 ## 1. Infrastructure & Scale
 
 - **Authoritative multi-zone servers** – Replace the single Fastify process that currently boots one world instance with a topology of authoritative game servers, shard managers, and load-balanced gateways. Each zone server should own simulation authority, coordinate transfers, and expose metrics for orchestration.【F:src/server/index.js†L5-L200】【F:src/core/createServerWorld.js†L1-L18】
+  - _Status update:_ `WORLD_ZONES` now enables multi-zone bootstrapping with dedicated persistence plus `/zones`, `/status`, and `/metrics` endpoints for orchestration visibility.【F:src/server/index.js†L39-L344】【F:docs/server-zones.md†L1-L67】
 - **Realtime networking upgrades** – Extend `ServerNetwork` with replication throttling, prioritised interest management, and configurable tick rates per zone so updates scale with population instead of broadcasting every packet to all sockets.【F:src/core/systems/ServerNetwork.js†L84-L124】【F:src/core/systems/Server.js†L3-L30】
 - **Resilience & observability** – Introduce health probes, autoscaling signals, and crash recovery for each service. Capture structured telemetry for tick time, bandwidth, and error rates to feed capacity planning and incident response.【F:src/server/index.js†L139-L181】
 

--- a/docs/server-zones.md
+++ b/docs/server-zones.md
@@ -1,0 +1,65 @@
+# Multi-Zone Server Operations
+
+Hyperfy's server can now host multiple authoritative simulation zones within a single
+process. This functionality supports the "Authoritative multi-zone servers" milestone in
+the [MMORPG roadmap](./mmorpg-roadmap.md) by allowing isolated persistence and runtime
+state per zone while continuing to share the existing asset and collection pipelines.
+
+## Configuration
+
+Set the `WORLD_ZONES` environment variable alongside the existing `WORLD` setting when
+booting the server. The value accepts either a JSON array or a comma-separated list.
+Each zone definition must include a unique `id`; optional fields provide a user-facing
+`label`, a relative `dataDir` for persistence, and a `tickRate` override (updates per
+second) that controls networking frequency for that zone.
+
+```bash
+# minimal comma-separated example
+WORLD=my-world \
+WORLD_ZONES="lobby,raid-01" \
+node src/server/index.js
+```
+
+```bash
+# JSON configuration with custom persistence folders and tick rates
+WORLD=my-world \
+WORLD_ZONES='[
+  {"id": "lobby", "label": "Public Lobby", "tickRate": 12},
+  {"id": "raid", "label": "Raid Instance", "dataDir": "zones/raid", "tickRate": 20}
+]' \
+node src/server/index.js
+```
+
+- When omitted, `WORLD_ZONES` defaults to a single `primary` zone that matches the
+  legacy behaviour.
+- `dataDir` values are validated to remain inside the repository and are created
+  automatically if they do not exist.
+- All zones reuse the shared asset pipeline (`/assets`) so existing CDN/CDN cache
+  flows continue to work.
+
+## Runtime Behaviour
+
+- Each zone receives a dedicated SQLite database and storage file inside its configured
+  `dataDir`, ensuring player inventories and blueprint state do not collide across
+  instances.
+- The WebSocket handshake accepts an optional `zone` query parameter. When omitted or
+  unknown, clients are routed to the default zone.
+- Server-side systems expose `world.zoneId` and `world.zoneLabel` to enable
+  zone-aware scripting or logging extensions.
+
+## Observability & Operations
+
+Three new HTTP endpoints expose zone health for orchestration and dashboards:
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /zones` | Lists configured zones, their tick settings, and player counts. |
+| `GET /status` | Extends the existing status payload with per-zone connection details. |
+| `GET /metrics` | Reports CPU/memory samples and tick counters per zone for monitoring. |
+
+The `GET /health` endpoint also returns a zone summary to aid load balancers that track
+instance vitality.
+
+These additions provide the foundation for sharded orchestration, load-aware routing,
+and automated monitoring pipelines that are essential for operating an MMORPG-scale
+deployment.

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -93,6 +93,86 @@ function buildPublicEnv(overrides) {
   return Object.freeze(merged)
 }
 
+const ZONE_ID_PATTERN = /^[a-z0-9][a-z0-9-_]*$/i
+
+function normaliseZoneId(value, index) {
+  if (typeof value !== 'string') {
+    throw new Error(`WORLD_ZONES[${index}].id must be a string`)
+  }
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw new Error(`WORLD_ZONES[${index}].id cannot be empty`)
+  }
+  if (!ZONE_ID_PATTERN.test(trimmed)) {
+    throw new Error(
+      `WORLD_ZONES[${index}].id must match ${ZONE_ID_PATTERN.toString()} (alphanumeric, hyphen, underscore)`
+    )
+  }
+  return trimmed
+}
+
+function parseZoneConfig(rawValue, worldDir) {
+  if (!rawValue) {
+    return [
+      Object.freeze({
+        id: 'primary',
+        label: 'Primary Zone',
+        dataDir: worldDir,
+        tickRate: null,
+      }),
+    ]
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(rawValue)
+  } catch (err) {
+    parsed = rawValue
+      .split(',')
+      .map(item => item.trim())
+      .filter(Boolean)
+      .map(id => ({ id }))
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error('WORLD_ZONES must be a JSON array or comma separated list with at least one entry')
+  }
+
+  const zones = []
+  for (let index = 0; index < parsed.length; index++) {
+    const descriptor = parsed[index]
+    const zone = typeof descriptor === 'string' ? { id: descriptor } : descriptor
+    if (!zone || typeof zone !== 'object') {
+      throw new Error(`WORLD_ZONES[${index}] must be a string or object`)
+    }
+
+    const id = normaliseZoneId(zone.id ?? zone.slug ?? zone.name, index)
+    const label = zone.label ? String(zone.label).trim() : id
+    const relativeDataDir = ensureRelativePath(zone.dataDir ?? path.join('zones', id), `WORLD_ZONES[${index}].dataDir`)
+    const dataDir = path.join(worldDir, relativeDataDir)
+
+    let tickRate = null
+    if (zone.tickRate !== undefined && zone.tickRate !== null && zone.tickRate !== '') {
+      const numeric = Number(zone.tickRate)
+      if (!Number.isFinite(numeric) || numeric <= 0) {
+        throw new Error(`WORLD_ZONES[${index}].tickRate must be a positive number if provided`)
+      }
+      tickRate = numeric
+    }
+
+    zones.push(
+      Object.freeze({
+        id,
+        label,
+        dataDir,
+        tickRate,
+      })
+    )
+  }
+
+  return zones
+}
+
 function buildServerConfig(options = {}) {
   const rootDir = options.rootDir ? path.resolve(options.rootDir) : defaultRootDir
 
@@ -100,6 +180,8 @@ function buildServerConfig(options = {}) {
   const worldDir = path.join(rootDir, worldName)
   const assetsDir = path.join(worldDir, 'assets')
   const collectionsDir = path.join(worldDir, 'collections')
+
+  const zoneConfig = parseZoneConfig(readEnv('WORLD_ZONES', { allowEmpty: true }), worldDir)
 
   const port = parseInteger(readEnv('PORT', { defaultValue: '3000' }), 'PORT', {
     min: 1,
@@ -160,6 +242,8 @@ function buildServerConfig(options = {}) {
     server: Object.freeze({
       port,
       saveInterval,
+      zones: Object.freeze(zoneConfig),
+      defaultZoneId: zoneConfig[0].id,
     }),
     auth: Object.freeze({
       jwtSecret,

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -7,20 +7,26 @@ import { importApp } from '../core/extras/appTools'
 import { defaults } from 'lodash-es'
 import { Ranks } from '../core/extras/ranks'
 
-let db
+const connections = new Map()
 
-export async function getDB(worldDir) {
-  const filename = path.join(worldDir, '/db.sqlite')
-  if (!db) {
-    db = Knex({
-      client: 'better-sqlite3',
-      connection: {
-        filename,
-      },
-      useNullAsDefault: true,
-    })
-    await migrate(db, worldDir)
+export async function getDB(worldDir, options = {}) {
+  const resolvedDir = path.resolve(worldDir)
+  const cached = connections.get(resolvedDir)
+  if (cached) {
+    return cached
   }
+
+  const filename = path.join(resolvedDir, '/db.sqlite')
+  const assetsRootDir = options.assetsRootDir ? path.resolve(options.assetsRootDir) : resolvedDir
+  const db = Knex({
+    client: 'better-sqlite3',
+    connection: {
+      filename,
+    },
+    useNullAsDefault: true,
+  })
+  await migrate(db, assetsRootDir)
+  connections.set(resolvedDir, db)
   return db
 }
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -4,7 +4,6 @@ import './bootstrap'
 
 import fs from 'fs-extra'
 import path from 'path'
-import { pipeline } from 'stream/promises'
 import Fastify from 'fastify'
 import ws from '@fastify/websocket'
 import cors from '@fastify/cors'
@@ -19,11 +18,18 @@ import { Storage } from './Storage'
 import { initCollections } from './collections'
 import { getServerConfig } from './config.js'
 
+function cloneCollections(data) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(data)
+  }
+  return JSON.parse(JSON.stringify(data))
+}
+
 const config = getServerConfig()
 const {
   rootDir,
   world: { dir: worldDir, assetsDir, collectionsDir },
-  server: { port },
+  server: { port, zones: configuredZones, defaultZoneId },
   public: publicConfig,
   auth,
   commitHash,
@@ -38,26 +44,83 @@ await fs.ensureDir(collectionsDir)
 await fs.copy(path.join(rootDir, 'src/world/assets'), path.join(assetsDir))
 await fs.copy(path.join(rootDir, 'src/world/collections'), path.join(collectionsDir))
 
-// init collections
-const collections = await initCollections({ collectionsDir, assetsDir })
+// init collections shared by all zones
+const baseCollections = await initCollections({ collectionsDir, assetsDir })
 
-// init db
-const db = await getDB(worldDir)
+// boot each configured zone with isolated persistence but shared assets
+const zones = new Map()
+for (const zoneConfig of configuredZones) {
+  await fs.ensureDir(zoneConfig.dataDir)
+  const db = await getDB(zoneConfig.dataDir, { assetsRootDir: worldDir })
+  const storage = new Storage(path.join(zoneConfig.dataDir, '/storage.json'))
+  const world = createServerWorld()
+  world.zoneId = zoneConfig.id
+  world.zoneLabel = zoneConfig.label
+  if (zoneConfig.tickRate) {
+    world.networkRate = 1 / zoneConfig.tickRate
+  }
+  world.assetsUrl = publicConfig.assetsUrl
+  world.collections.deserialize(cloneCollections(baseCollections))
+  world.init({ db, storage, assetsDir })
+  zones.set(zoneConfig.id, {
+    world,
+    db,
+    storage,
+    config: zoneConfig,
+  })
+}
 
-// init storage
-const storage = new Storage(path.join(worldDir, '/storage.json'))
+if (!zones.size) {
+  throw new Error('No zones could be initialised')
+}
 
-// create world
-const world = createServerWorld()
-world.assetsUrl = publicConfig.assetsUrl
-world.collections.deserialize(collections)
-world.init({ db, storage, assetsDir })
+const defaultZone = zones.get(defaultZoneId)
+if (!defaultZone) {
+  throw new Error(`Default zone "${defaultZoneId}" is not available`)
+}
+
+function resolveZone(zoneId) {
+  if (zoneId && zones.has(zoneId)) {
+    return zones.get(zoneId)
+  }
+  return defaultZone
+}
+
+function getDefaultWorld() {
+  return resolveZone(defaultZoneId).world
+}
+
+function getZoneSnapshots() {
+  const snapshots = []
+  for (const [zoneId, zone] of zones) {
+    const world = zone.world
+    const sockets = []
+    for (const socket of world.network.sockets.values()) {
+      sockets.push({
+        id: socket.player?.data?.userId ?? null,
+        name: socket.player?.data?.name ?? null,
+        position: socket.player?.position?.value?.toArray?.() ?? null,
+      })
+    }
+    snapshots.push({
+      id: zoneId,
+      label: zone.config.label,
+      tickRate: zone.config.tickRate,
+      networkRate: world.networkRate,
+      frame: world.frame,
+      time: world.time,
+      sockets,
+    })
+  }
+  return snapshots
+}
 
 const fastify = Fastify({ logger: { level: 'error' } })
 
 fastify.register(cors)
 fastify.register(compress)
 fastify.get('/', async (req, reply) => {
+  const world = getDefaultWorld()
   const title = world.settings.title || 'World'
   const desc = world.settings.desc || ''
   const image = world.resolveURL(world.settings.image?.url) || ''
@@ -138,11 +201,18 @@ fastify.get('/api/upload-check', async (req, reply) => {
 
 fastify.get('/health', async (request, reply) => {
   try {
-    // Basic health check
+    const snapshots = getZoneSnapshots()
     const health = {
       status: 'ok',
       timestamp: new Date().toISOString(),
       uptime: process.uptime(),
+      zones: snapshots.map(snapshot => ({
+        id: snapshot.id,
+        label: snapshot.label,
+        players: snapshot.sockets.length,
+        frame: snapshot.frame,
+        time: snapshot.time,
+      })),
     }
 
     return reply.code(200).send(health)
@@ -155,20 +225,82 @@ fastify.get('/health', async (request, reply) => {
   }
 })
 
+fastify.get('/zones', async (request, reply) => {
+  try {
+    const snapshots = getZoneSnapshots()
+    return reply.code(200).send({
+      defaultZoneId,
+      count: snapshots.length,
+      zones: snapshots.map(snapshot => ({
+        id: snapshot.id,
+        label: snapshot.label,
+        tickRate: snapshot.tickRate,
+        networkRate: snapshot.networkRate,
+        players: snapshot.sockets.length,
+        frame: snapshot.frame,
+        time: snapshot.time,
+      })),
+    })
+  } catch (error) {
+    console.error('Zones endpoint failed:', error)
+    return reply.code(503).send({
+      status: 'error',
+      timestamp: new Date().toISOString(),
+    })
+  }
+})
+
+fastify.get('/metrics', async (request, reply) => {
+  try {
+    const metrics = []
+    for (const [zoneId, zone] of zones) {
+      const stats = await zone.world.monitor.getStats()
+      metrics.push({
+        id: zoneId,
+        label: zone.config.label,
+        players: zone.world.network.sockets.size,
+        frame: zone.world.frame,
+        time: zone.world.time,
+        networkRate: zone.world.networkRate,
+        cpu: stats.currentCPU,
+        maxCPU: stats.maxCPU,
+        memory: stats.currentMemory,
+        maxMemory: stats.maxMemory,
+      })
+    }
+
+    return reply.code(200).send({
+      timestamp: new Date().toISOString(),
+      zones: metrics,
+    })
+  } catch (error) {
+    console.error('Metrics endpoint failed:', error)
+    return reply.code(503).send({
+      status: 'error',
+      timestamp: new Date().toISOString(),
+    })
+  }
+})
+
 fastify.get('/status', async (request, reply) => {
   try {
+    const snapshots = getZoneSnapshots()
+    const defaultSnapshot = snapshots.find(snapshot => snapshot.id === defaultZoneId)
     const status = {
-      uptime: Math.round(world.time),
+      uptime: Math.round(getDefaultWorld().time),
       protected: auth.hasAdminCode,
-      connectedUsers: [],
+      connectedUsers: defaultSnapshot ? defaultSnapshot.sockets : [],
       commitHash,
-    }
-    for (const socket of world.network.sockets.values()) {
-      status.connectedUsers.push({
-        id: socket.player.data.userId,
-        position: socket.player.position.value.toArray(),
-        name: socket.player.data.name,
-      })
+      zones: snapshots.map(snapshot => ({
+        id: snapshot.id,
+        label: snapshot.label,
+        tickRate: snapshot.tickRate,
+        networkRate: snapshot.networkRate,
+        frame: snapshot.frame,
+        time: snapshot.time,
+        players: snapshot.sockets.length,
+        connectedUsers: snapshot.sockets,
+      })),
     }
 
     return reply.code(200).send(status)
@@ -196,7 +328,19 @@ try {
 
 async function worldNetwork(fastify) {
   fastify.get('/ws', { websocket: true }, (ws, req) => {
-    world.network.onConnection(ws, req.query)
+    const baseQuery = { ...(req.query ?? {}) }
+    const requestedZone = Array.isArray(baseQuery.zone)
+      ? baseQuery.zone[0]
+      : typeof baseQuery.zone === 'string'
+        ? baseQuery.zone
+        : undefined
+    const zone = resolveZone(requestedZone)
+    if (!zone) {
+      ws.close(1008, 'Zone unavailable')
+      return
+    }
+    baseQuery.zone = zone.config.id
+    zone.world.network.onConnection(ws, baseQuery)
   })
 }
 


### PR DESCRIPTION
## Summary
- add support for configuring multiple server zones via the new `WORLD_ZONES` env var and create isolated persistence for each zone
- refactor the Fastify bootstrap to spin up per-zone worlds, update the WebSocket handshake, and expose `/zones`, `/status`, and `/metrics` telemetry endpoints
- document the zone workflow and mark roadmap progress toward multi-zone infrastructure

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68ebdda60fbc832dac21f305f8beb7cc