### PR TITLE
Add character persistence service and REST endpoints

### DIFF
--- a/docs/mmorpg-systems.md
+++ b/docs/mmorpg-systems.md
@@ -20,7 +20,7 @@ required.
 | --- | --- | --- |
 | Zone storage | Each zone provisions a dedicated SQLite database and JSON storage to avoid data collisions. | [Server entrypoint](../src/server/index.js). |
 | Collections hydration | Base collections load once, then clone into every zone during boot. | [Server entrypoint](../src/server/index.js). |
-| Character data services | Not yet implemented; roadmap calls for account, inventory, and quest schemas. | [Roadmap section](./mmorpg-roadmap.md#2-persistence--progression). |
+| Character data services | `ServerCharacters` now provisions per-zone character, inventory, and quest records with REST accessors. | [Server character system](../src/core/systems/ServerCharacters.js) and [server entrypoint](../src/server/index.js). |
 
 ## 3. Gameplay & Social Layers
 

--- a/src/core/createServerWorld.js
+++ b/src/core/createServerWorld.js
@@ -3,6 +3,7 @@ import { World } from './World'
 import { Server } from './systems/Server'
 import { ServerLiveKit } from './systems/ServerLiveKit'
 import { ServerNetwork } from './systems/ServerNetwork'
+import { ServerCharacters } from './systems/ServerCharacters'
 import { ServerLoader } from './systems/ServerLoader'
 import { ServerEnvironment } from './systems/ServerEnvironment'
 import { ServerMonitor } from './systems/ServerMonitor'
@@ -15,5 +16,6 @@ export function createServerWorld() {
   world.register('loader', ServerLoader)
   world.register('environment', ServerEnvironment)
   world.register('monitor', ServerMonitor)
+  world.register('characters', ServerCharacters)
   return world
 }

--- a/src/core/systems/ServerCharacters.js
+++ b/src/core/systems/ServerCharacters.js
@@ -1,0 +1,387 @@
+import moment from 'moment'
+import { cloneDeep } from 'lodash-es'
+import { System } from './System'
+import { uuid } from '../utils'
+
+const DEFAULT_POSITION = [0, 0, 0]
+const DEFAULT_QUATERNION = [0, 0, 0, 1]
+const DEFAULT_STATS = {
+  health: 100,
+  stamina: 100,
+  mana: 0,
+}
+
+function safeParseJSON(value, fallback) {
+  if (!value) return cloneDeep(fallback)
+  try {
+    return JSON.parse(value)
+  } catch (err) {
+    return cloneDeep(fallback)
+  }
+}
+
+function mapInventoryRow(row) {
+  return {
+    id: row.id,
+    characterId: row.characterId,
+    itemId: row.itemId,
+    slot: row.slot,
+    quantity: row.quantity,
+    metadata: safeParseJSON(row.metadata, {}),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+function mapQuestRow(row) {
+  return {
+    id: row.id,
+    characterId: row.characterId,
+    questId: row.questId,
+    status: row.status,
+    progress: safeParseJSON(row.progress, {}),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+export class ServerCharacters extends System {
+  constructor(world) {
+    super(world)
+    this.zoneId = null
+    this.db = null
+    this.charactersById = new Map()
+    this.charactersByUserId = new Map()
+  }
+
+  async init({ db }) {
+    this.db = db
+    this.zoneId = this.world.zoneId ?? 'default'
+  }
+
+  async getCharacterById(characterId) {
+    if (!characterId) return null
+    const cached = this.charactersById.get(characterId)
+    if (cached) return cached
+    const row = await this.db('characters').where({ id: characterId }).first()
+    if (!row) return null
+    const character = await this.#hydrateFromRow(row)
+    this.#cacheCharacter(character)
+    return character
+  }
+
+  async getCharacterByUserId(userId, options = {}) {
+    if (!userId) return null
+    const { create = false, name = 'Adventurer', spawn = null } = options
+    const cached = this.charactersByUserId.get(userId)
+    if (cached) return cached
+    let row = await this.db('characters')
+      .where({ userId, zoneId: this.zoneId })
+      .first()
+    if (!row && create) {
+      row = await this.#createCharacterRow(userId, name, spawn)
+    }
+    if (!row) return null
+    const character = await this.#hydrateFromRow(row)
+    this.#cacheCharacter(character)
+    return character
+  }
+
+  serializeForClient(character) {
+    if (!character) return null
+    return {
+      id: character.id,
+      userId: character.userId,
+      zoneId: character.zoneId,
+      name: character.name,
+      level: character.level,
+      experience: character.experience,
+      currency: character.currency,
+      stats: cloneDeep(character.stats ?? {}),
+      position: cloneDeep(character.position ?? DEFAULT_POSITION),
+      quaternion: cloneDeep(character.quaternion ?? DEFAULT_QUATERNION),
+      inventory: character.inventory.map(item => ({ ...item, metadata: cloneDeep(item.metadata ?? {}) })),
+      quests: character.quests.map(quest => ({ ...quest, progress: cloneDeep(quest.progress ?? {}) })),
+      lastLogin: character.lastLogin,
+      lastLogout: character.lastLogout,
+      createdAt: character.createdAt,
+      updatedAt: character.updatedAt,
+    }
+  }
+
+  attachToPlayer(player, character) {
+    if (!player || !character) return null
+    const snapshot = this.serializeForClient(character)
+    player.data.characterId = character.id
+    player.data.character = snapshot
+    player.data.level = character.level
+    player.data.experience = character.experience
+    player.data.currency = character.currency
+    player.data.stats = cloneDeep(character.stats)
+    player.data.inventory = snapshot.inventory
+    player.data.quests = snapshot.quests
+    if (typeof character.stats?.health === 'number') {
+      player.data.health = character.stats.health
+    }
+    return snapshot
+  }
+
+  resolveSpawn(character, fallbackSpawn) {
+    const fallbackPosition = fallbackSpawn?.position ?? DEFAULT_POSITION
+    const fallbackQuaternion = fallbackSpawn?.quaternion ?? DEFAULT_QUATERNION
+    const position = character?.position?.length ? character.position.slice() : fallbackPosition.slice()
+    const quaternion = character?.quaternion?.length ? character.quaternion.slice() : fallbackQuaternion.slice()
+    return { position, quaternion }
+  }
+
+  async markLogin(characterId, timestamp = moment().toISOString()) {
+    const character = await this.getCharacterById(characterId)
+    if (!character) return
+    character.lastLogin = timestamp
+    character.updatedAt = timestamp
+    await this.db('characters').where({ id: characterId }).update({ lastLogin: timestamp, updatedAt: timestamp })
+  }
+
+  async persistFromPlayer(player) {
+    if (!player?.data?.characterId) return
+    const character = await this.getCharacterById(player.data.characterId)
+    if (!character) return
+    const now = moment().toISOString()
+    const position = player.data.position ? player.data.position.slice() : DEFAULT_POSITION.slice()
+    const quaternion = player.data.quaternion ? player.data.quaternion.slice() : DEFAULT_QUATERNION.slice()
+    const stats = { ...(character.stats ?? {}), ...(player.data.stats ?? {}) }
+    if (typeof player.data.health === 'number') {
+      stats.health = player.data.health
+    }
+    character.position = position
+    character.quaternion = quaternion
+    character.name = player.data.name ?? character.name
+    character.level = player.data.level ?? character.level
+    character.experience = player.data.experience ?? character.experience
+    character.currency = player.data.currency ?? character.currency
+    character.stats = stats
+    character.updatedAt = now
+    character.lastLogout = now
+    await this.db('characters')
+      .where({ id: character.id })
+      .update({
+        name: character.name,
+        level: character.level,
+        experience: character.experience,
+        currency: character.currency,
+        stats: JSON.stringify(stats ?? {}),
+        position: JSON.stringify(position),
+        quaternion: JSON.stringify(quaternion),
+        updatedAt: now,
+        lastLogout: now,
+      })
+  }
+
+  applyEntityPatch(entity, patch) {
+    if (!entity?.data?.characterId) return
+    const character = this.charactersById.get(entity.data.characterId)
+    if (!character) return
+    const has = key => Object.prototype.hasOwnProperty.call(patch, key)
+    if (has('name')) {
+      character.name = patch.name
+    }
+    if (has('health')) {
+      character.stats = character.stats ?? { ...DEFAULT_STATS }
+      character.stats.health = patch.health
+    }
+    if (has('p')) {
+      character.position = patch.p.slice()
+    }
+    if (has('q')) {
+      character.quaternion = patch.q.slice()
+    }
+    if (has('stats')) {
+      character.stats = { ...(character.stats ?? {}), ...patch.stats }
+    }
+    if (has('level')) {
+      character.level = patch.level
+    }
+    if (has('experience')) {
+      character.experience = patch.experience
+    }
+    if (has('currency')) {
+      character.currency = patch.currency
+    }
+  }
+
+  async updateCharacterName(characterId, name) {
+    if (!characterId || !name) return
+    const character = await this.getCharacterById(characterId)
+    if (!character) return
+    const now = moment().toISOString()
+    character.name = name
+    character.updatedAt = now
+    await this.db('characters').where({ id: characterId }).update({ name, updatedAt: now })
+  }
+
+  async upsertInventoryItem(characterId, item) {
+    if (!characterId || !item?.itemId) return null
+    const now = moment().toISOString()
+    const slot = item.slot ?? null
+    let row = await this.db('character_inventories')
+      .where({ characterId, itemId: item.itemId, slot })
+      .first()
+    if (row) {
+      const quantity = item.quantity ?? row.quantity
+      const metadata = JSON.stringify(item.metadata ?? safeParseJSON(row.metadata, {}))
+      await this.db('character_inventories')
+        .where({ id: row.id })
+        .update({ quantity, metadata, updatedAt: now })
+      row = { ...row, quantity, metadata, updatedAt: now }
+    } else {
+      const id = item.id ?? uuid()
+      row = {
+        id,
+        characterId,
+        itemId: item.itemId,
+        slot,
+        quantity: item.quantity ?? 1,
+        metadata: JSON.stringify(item.metadata ?? {}),
+        createdAt: now,
+        updatedAt: now,
+      }
+      await this.db('character_inventories').insert(row)
+    }
+    const entry = mapInventoryRow(row)
+    const character = await this.getCharacterById(characterId)
+    if (character) {
+      const index = character.inventory.findIndex(i => i.itemId === entry.itemId && i.slot === entry.slot)
+      if (index >= 0) {
+        character.inventory[index] = entry
+      } else {
+        character.inventory.push(entry)
+      }
+      character.updatedAt = now
+    }
+    return entry
+  }
+
+  async removeInventoryItem(characterId, itemId, slot = null) {
+    if (!characterId || !itemId) return
+    const row = await this.db('character_inventories')
+      .where({ characterId, itemId, slot })
+      .first()
+    if (!row) return
+    await this.db('character_inventories').where({ id: row.id }).delete()
+    const character = await this.getCharacterById(characterId)
+    if (character) {
+      character.inventory = character.inventory.filter(item => !(item.itemId === itemId && item.slot === slot))
+      character.updatedAt = moment().toISOString()
+    }
+  }
+
+  async upsertQuestState(characterId, questId, data = {}) {
+    if (!characterId || !questId) return null
+    const now = moment().toISOString()
+    let row = await this.db('character_quests')
+      .where({ characterId, questId })
+      .first()
+    if (row) {
+      const status = data.status ?? row.status
+      const progress = JSON.stringify(data.progress ?? safeParseJSON(row.progress, {}))
+      await this.db('character_quests')
+        .where({ id: row.id })
+        .update({ status, progress, updatedAt: now })
+      row = { ...row, status, progress, updatedAt: now }
+    } else {
+      row = {
+        id: uuid(),
+        characterId,
+        questId,
+        status: data.status ?? 'active',
+        progress: JSON.stringify(data.progress ?? {}),
+        createdAt: now,
+        updatedAt: now,
+      }
+      await this.db('character_quests').insert(row)
+    }
+    const entry = mapQuestRow(row)
+    const character = await this.getCharacterById(characterId)
+    if (character) {
+      const index = character.quests.findIndex(quest => quest.questId === questId)
+      if (index >= 0) {
+        character.quests[index] = entry
+      } else {
+        character.quests.push(entry)
+      }
+      character.updatedAt = now
+    }
+    return entry
+  }
+
+  async removeQuest(characterId, questId) {
+    if (!characterId || !questId) return
+    const row = await this.db('character_quests').where({ characterId, questId }).first()
+    if (!row) return
+    await this.db('character_quests').where({ id: row.id }).delete()
+    const character = await this.getCharacterById(characterId)
+    if (character) {
+      character.quests = character.quests.filter(quest => quest.questId !== questId)
+      character.updatedAt = moment().toISOString()
+    }
+  }
+
+  async #createCharacterRow(userId, name, spawn) {
+    const now = moment().toISOString()
+    const position = Array.isArray(spawn?.position) ? spawn.position.slice() : DEFAULT_POSITION.slice()
+    const quaternion = Array.isArray(spawn?.quaternion) ? spawn.quaternion.slice() : DEFAULT_QUATERNION.slice()
+    const row = {
+      id: uuid(),
+      userId,
+      zoneId: this.zoneId,
+      name,
+      level: 1,
+      experience: 0,
+      currency: 0,
+      stats: JSON.stringify({ ...DEFAULT_STATS }),
+      position: JSON.stringify(position),
+      quaternion: JSON.stringify(quaternion),
+      createdAt: now,
+      updatedAt: now,
+      lastLogin: now,
+      lastLogout: null,
+    }
+    await this.db('characters').insert(row)
+    return row
+  }
+
+  async #hydrateFromRow(row) {
+    const character = {
+      id: row.id,
+      userId: row.userId,
+      zoneId: row.zoneId,
+      name: row.name,
+      level: row.level,
+      experience: row.experience,
+      currency: row.currency,
+      stats: safeParseJSON(row.stats, DEFAULT_STATS),
+      position: safeParseJSON(row.position, DEFAULT_POSITION),
+      quaternion: safeParseJSON(row.quaternion, DEFAULT_QUATERNION),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      lastLogin: row.lastLogin,
+      lastLogout: row.lastLogout,
+      inventory: [],
+      quests: [],
+    }
+    const inventoryRows = await this.db('character_inventories')
+      .where({ characterId: character.id })
+      .orderBy('createdAt', 'asc')
+    character.inventory = inventoryRows.map(mapInventoryRow)
+    const questRows = await this.db('character_quests')
+      .where({ characterId: character.id })
+      .orderBy('createdAt', 'asc')
+    character.quests = questRows.map(mapQuestRow)
+    return character
+  }
+
+  #cacheCharacter(character) {
+    this.charactersById.set(character.id, character)
+    this.charactersByUserId.set(character.userId, character)
+  }
+}

--- a/src/core/systems/ServerNetwork.js
+++ b/src/core/systems/ServerNetwork.js
@@ -256,6 +256,15 @@ export class ServerNetwork extends System {
         return
       }
 
+      const character = await this.world.characters.getCharacterByUserId(user.id, {
+        create: true,
+        name: name || user.name,
+        spawn: this.spawn,
+      })
+      const spawnTransform = this.world.characters.resolveSpawn(character, this.spawn)
+      const characterHealth = character?.stats?.health ?? HEALTH_MAX
+      const resolvedName = character?.name || name || user.name
+
       // livekit options
       const livekit = await this.world.livekit.serialize(user.id)
 
@@ -267,19 +276,27 @@ export class ServerNetwork extends System {
         {
           id: user.id,
           type: 'player',
-          position: this.spawn.position.slice(),
-          quaternion: this.spawn.quaternion.slice(),
+          position: spawnTransform.position,
+          quaternion: spawnTransform.quaternion,
           owner: socket.id, // deprecated, same as userId
           userId: user.id, // deprecated, same as userId
-          name: name || user.name,
-          health: HEALTH_MAX,
+          name: resolvedName,
+          health: characterHealth,
           avatar: user.avatar || this.world.settings.avatar?.url || 'asset://avatar.vrm',
           sessionAvatar: avatar || null,
           rank: user.rank,
           enteredAt: Date.now(),
+          characterId: character?.id || null,
+          level: character?.level ?? 1,
+          experience: character?.experience ?? 0,
+          currency: character?.currency ?? 0,
+          stats: character?.stats ?? null,
         },
         true
       )
+
+      const characterSnapshot = this.world.characters.attachToPlayer(socket.player, character)
+      await this.world.characters.markLogin(character?.id)
 
       this.world.companions.ensureCompanionForPlayer(socket.player.data.id, { broadcast: false })
       this.world.mounts.ensureMountForPlayer(socket.player.data.id, { broadcast: false })
@@ -301,6 +318,7 @@ export class ServerNetwork extends System {
         livekit,
         authToken,
         hasAdminCode: AUTH_CONFIG.hasAdminCode,
+        character: characterSnapshot,
       })
 
       this.world.companions.broadcastState()
@@ -367,6 +385,7 @@ export class ServerNetwork extends System {
           createdAt: moment().toISOString(),
         })
         await this.db('users').where('id', userId).update({ name })
+        await this.world.characters.updateCharacterName(player.data.characterId, name)
       }
     }
     if (cmd === 'spawn') {
@@ -483,6 +502,7 @@ export class ServerNetwork extends System {
       this.dirtyApps.add(entity.data.id)
     }
     if (entity.isPlayer) {
+      this.world.characters.applyEntityPatch(entity, data)
       // persist player name and avatar changes
       const changes = {}
       let changed
@@ -633,6 +653,9 @@ export class ServerNetwork extends System {
 
   onDisconnect = (socket, code) => {
     this.world.livekit.clearModifiers(socket.id)
+    this.world.characters
+      .persistFromPlayer(socket.player)
+      .catch(err => console.error('failed to persist character on disconnect', err))
     socket.player.destroy(true)
     this.sockets.delete(socket.id)
   }

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -413,4 +413,56 @@ const migrations = [
     const value = JSON.stringify(settings)
     await db('config').where('key', 'settings').update({ value })
   },
+  // add character persistence tables
+  async db => {
+    const hasCharacters = await db.schema.hasTable('characters')
+    if (!hasCharacters) {
+      await db.schema.createTable('characters', table => {
+        table.string('id').primary()
+        table.string('userId').notNullable().index()
+        table.string('zoneId').notNullable().index()
+        table.string('name').notNullable()
+        table.integer('level').notNullable().defaultTo(1)
+        table.integer('experience').notNullable().defaultTo(0)
+        table.integer('currency').notNullable().defaultTo(0)
+        table.text('stats').notNullable()
+        table.text('position').notNullable()
+        table.text('quaternion').notNullable()
+        table.timestamp('createdAt').notNullable()
+        table.timestamp('updatedAt').notNullable()
+        table.timestamp('lastLogin').nullable()
+        table.timestamp('lastLogout').nullable()
+        table.unique(['userId', 'zoneId'])
+      })
+    }
+    const hasInventory = await db.schema.hasTable('character_inventories')
+    if (!hasInventory) {
+      await db.schema.createTable('character_inventories', table => {
+        table.string('id').primary()
+        table.string('characterId').notNullable().index()
+        table.string('itemId').notNullable()
+        table.string('slot').nullable()
+        table.integer('quantity').notNullable().defaultTo(1)
+        table.text('metadata').notNullable()
+        table.timestamp('createdAt').notNullable()
+        table.timestamp('updatedAt').notNullable()
+        table.unique(['characterId', 'itemId', 'slot'])
+        table.foreign('characterId').references('characters.id').onDelete('CASCADE')
+      })
+    }
+    const hasQuests = await db.schema.hasTable('character_quests')
+    if (!hasQuests) {
+      await db.schema.createTable('character_quests', table => {
+        table.string('id').primary()
+        table.string('characterId').notNullable().index()
+        table.string('questId').notNullable()
+        table.string('status').notNullable()
+        table.text('progress').notNullable()
+        table.timestamp('createdAt').notNullable()
+        table.timestamp('updatedAt').notNullable()
+        table.unique(['characterId', 'questId'])
+        table.foreign('characterId').references('characters.id').onDelete('CASCADE')
+      })
+    }
+  },
 ]

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -199,6 +199,94 @@ fastify.get('/api/upload-check', async (req, reply) => {
   return { exists }
 })
 
+fastify.get('/api/zones/:zoneId/characters/:userId', async (req, reply) => {
+  const { zoneId, userId } = req.params
+  const zone = resolveZone(zoneId)
+  if (!zone) {
+    reply.code(404)
+    return { error: 'Zone not found' }
+  }
+  const character = await zone.world.characters.getCharacterByUserId(userId, { create: false })
+  if (!character) {
+    reply.code(404)
+    return { error: 'Character not found' }
+  }
+  return { character: zone.world.characters.serializeForClient(character) }
+})
+
+fastify.post('/api/zones/:zoneId/characters/:userId', async (req, reply) => {
+  const { zoneId, userId } = req.params
+  const zone = resolveZone(zoneId)
+  if (!zone) {
+    reply.code(404)
+    return { error: 'Zone not found' }
+  }
+  const payload = req.body ?? {}
+  const character = await zone.world.characters.getCharacterByUserId(userId, {
+    create: true,
+    name: payload.name,
+    spawn: payload.spawn ?? zone.world.network.spawn,
+  })
+  if (payload?.name) {
+    await zone.world.characters.updateCharacterName(character.id, payload.name)
+  }
+  return { character: zone.world.characters.serializeForClient(character) }
+})
+
+fastify.post('/api/zones/:zoneId/characters/:characterId/inventory', async (req, reply) => {
+  const { zoneId, characterId } = req.params
+  const zone = resolveZone(zoneId)
+  if (!zone) {
+    reply.code(404)
+    return { error: 'Zone not found' }
+  }
+  const item = await zone.world.characters.upsertInventoryItem(characterId, req.body ?? {})
+  if (!item) {
+    reply.code(400)
+    return { error: 'Invalid inventory payload' }
+  }
+  return { item }
+})
+
+fastify.delete('/api/zones/:zoneId/characters/:characterId/inventory/:itemId', async (req, reply) => {
+  const { zoneId, characterId, itemId } = req.params
+  const zone = resolveZone(zoneId)
+  if (!zone) {
+    reply.code(404)
+    return { error: 'Zone not found' }
+  }
+  const rawSlot = req.query?.slot
+  const slot = rawSlot === undefined || rawSlot === null || rawSlot === 'null' || rawSlot === 'undefined' ? null : rawSlot
+  await zone.world.characters.removeInventoryItem(characterId, itemId, slot)
+  return { success: true }
+})
+
+fastify.post('/api/zones/:zoneId/characters/:characterId/quests', async (req, reply) => {
+  const { zoneId, characterId } = req.params
+  const zone = resolveZone(zoneId)
+  if (!zone) {
+    reply.code(404)
+    return { error: 'Zone not found' }
+  }
+  const quest = await zone.world.characters.upsertQuestState(characterId, req.body?.questId, req.body ?? {})
+  if (!quest) {
+    reply.code(400)
+    return { error: 'Invalid quest payload' }
+  }
+  return { quest }
+})
+
+fastify.delete('/api/zones/:zoneId/characters/:characterId/quests/:questId', async (req, reply) => {
+  const { zoneId, characterId, questId } = req.params
+  const zone = resolveZone(zoneId)
+  if (!zone) {
+    reply.code(404)
+    return { error: 'Zone not found' }
+  }
+  await zone.world.characters.removeQuest(characterId, questId)
+  return { success: true }
+})
+
 fastify.get('/health', async (request, reply) => {
   try {
     const snapshots = getZoneSnapshots()


### PR DESCRIPTION
## Summary
- add a server-side character persistence system with caching and serialization utilities
- register the character system in the server world, wire it into player connection flows, and expose character data in snapshots
- extend the database schema and HTTP API with character, inventory, and quest endpoints and update the MMORPG systems guide

## Testing
- npm run lint *(fails: existing lint violations across legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68ebe6049c58832da6dc4ee1ae8aef9b