### PR TITLE
Document app lifecycle and material cloning

### DIFF
--- a/docs/scripting/README.md
+++ b/docs/scripting/README.md
@@ -8,7 +8,26 @@ Once scripting is stable we'll move toward a forward compatible model, which wil
 
 ## Lifecycle
 
-TODO: explain the app lifecycle across client and server
+Hyperfy worlds run the same simulation loop on both the authoritative server and on every connected client. Each tick of the
+[`World`](../world/World.md) advances through fixed updates, variable updates, late updates, and commit phases, so scripts only
+execute during the portions that they explicitly subscribe to. 【F:src/core/World.js†L21-L123】
+
+When a world boots, the server loads the saved blueprints for every app and calls [`App.build`](../app/App.md). This fetches the
+GLB, converts it into a node hierarchy, and then executes the app script if the instance is active. The same build pipeline
+runs on each client as soon as the server streams the blueprint snapshot, so both environments see the same node graph and
+scripted behaviour. 【F:src/core/entities/App.js†L21-L144】
+
+Scripts live side-by-side on the server and client. Networking keeps them in sync: the server is the source of truth for
+`app.state`, so new clients receive the latest state during their initial snapshot, and custom events relayed with
+`app.send`/`app.emit` travel through the [Apps system](../app/App.md#send-name-data-skipnetworkid). 【F:docs/scripting/app/App.md†L25-L53】
+
+Once a script is running, the app emits `fixedUpdate`, `update`, and `lateUpdate` callbacks during the corresponding world
+phases on any side where the script is active. Subscribing with `app.on('update', ...)` marks the app as "hot", ensuring the
+engine invokes it every frame; unsubscribing relinquishes those ticks to keep idle apps cheap. 【F:src/core/entities/App.js†L151-L190】
+
+Whenever a blueprint changes (for example after publishing a new model or script) or an app is removed, the engine first fires
+`destroy`, releases any grabbed controls, deactivates spawned world nodes, and clears event listeners. The app then rebuilds
+from the new data or shuts down cleanly, so both server and clients converge on the same version. 【F:src/core/entities/App.js†L144-L216】
 
 ## Apps
 

--- a/docs/scripting/app/App.md
+++ b/docs/scripting/app/App.md
@@ -65,7 +65,20 @@ Creates and returns a node of the specified name.
 
 #### `.control(options)`: Control
 
-TODO: provides control to a client to respond to inputs and move the camera etc
+Requests a high-priority input binding for the app. The optional `options` object is passed through to the control system, so
+you can specify an `onRelease` callback to clean up when the binding is lost. Apps always receive `ControlPriorities.APP`, so
+their inputs trump the local player while the control is active. 【F:src/core/systems/Apps.js†L307-L324】【F:src/core/systems/ClientControls.js†L246-L303】
+
+The returned handle lazily exposes input channels. Asking for `control.keyW` or `control.mouseLeft` creates button trackers with
+`down`, `pressed`, and `released` flags plus `onPress`/`onRelease` hooks; setting `capture = true` on a button or vector stops
+lower-priority bindings from seeing the event. Pointer and XR helpers expose the latest `position`, `coords`, and `delta`, and
+they include `lock()`/`unlock()` helpers that forward to the browser pointer-lock API (remember to call these from a user
+gesture). Screen metadata and scroll values are also available so UI can respond to viewport changes. 【F:src/core/systems/ClientControls.js†L266-L392】【F:src/core/systems/ClientControls.js†L640-L725】
+
+For camera-driven experiences you can read and write through `control.camera`: enable `camera.write = true` to drive the rig,
+update its `position`, `quaternion`, or `zoom`, and use the bound Euler `rotation` helper for yaw/pitch style controls. When the
+control should go away, call `control.release()` or rely on `destroy` handlers—apps automatically release any bound controls
+before rebuilding or shutting down. 【F:src/core/systems/ClientControls.js†L214-L235】【F:src/core/entities/App.js†L144-L216】
 
 #### `.configure(fields)`
 

--- a/docs/supported-files/models.md
+++ b/docs/supported-files/models.md
@@ -18,11 +18,22 @@ This not only reduces the file size of your model, but our engine is able to bet
 
 ## LODs
 
-- TODO: lod node
-- TODO: inserting lod children
+- Add a custom property named `node` with the value `lod` on an Empty or collection root to mark it as an LOD group. The
+  converter recognises this flag and spawns a dedicated [`LOD` node](../scripting/nodes/types/LOD.md) at runtime. 【F:src/core/extras/glbToNodes.js†L40-L55】
+- Toggle `scaleAware` on the same object when you want distances to scale with the rendered model; it maps straight through to
+  the node's `scaleAware` property. 【F:src/core/extras/glbToNodes.js†L40-L55】
+- Give each child mesh a `maxDistance` custom property (in metres). During import the loader uses that value when inserting the
+  child into the LOD so that higher-detail meshes disable themselves automatically. The bundled Blender panel exposes this field
+  as **Max Distance** to make editing easier. 【F:src/core/extras/glbToNodes.js†L12-L33】【F:docs/extras/blender-addon.py†L776-L865】
 
 ## Collision
 
-- TODO: rigidbody node
-- TODO: collider node
-- TODO: wireframe display
+- Create a rigidbody root by setting `node = rigidbody` on an Empty. Optional properties such as `type` (`static`, `kinematic`,
+  or `dynamic`) and `mass` are preserved on export and initialise the [`RigidBody` node](../scripting/nodes/types/RigidBody.md)
+  in the engine. 【F:src/core/extras/glbToNodes.js†L56-L68】
+- Add collider children underneath the rigidbody. Setting `node = collider` on a mesh plus flags like `convex`, `trigger`, or a
+  custom `layer` makes the importer emit [`Collider` nodes](../scripting/nodes/types/Collider.md) that PhysX can attach to the
+  rigidbody. The addon includes Convex and Trigger toggles so you can confirm their state directly inside Blender. 【F:src/core/extras/glbToNodes.js†L69-L89】【F:docs/extras/blender-addon.py†L728-L756】
+- Collider meshes act purely as metadata—the engine consumes their geometry and discards their materials—so keep them as simple
+  single-material shapes that are easy to read in wireframe. Complex, multi-material collider meshes are ignored during import,
+  matching the warning in the loader. 【F:src/core/extras/glbToNodes.js†L69-L83】

--- a/src/core/systems/Stage.js
+++ b/src/core/systems/Stage.js
@@ -206,16 +206,17 @@ export class Stage extends System {
         raw.fog = value
         raw.needsUpdate = true
       },
-      // TODO: not yet
-      // clone() {
-      //   return self.createMaterial(options).proxy
-      // },
+      clone() {
+        const cloned = self.createMaterial({ raw })
+        return cloned.proxy
+      },
       get _ref() {
         if (world._allowMaterial) return material
       },
     }
     material.raw = raw
     material.proxy = proxy
+    material.clone = () => self.createMaterial({ raw })
     return material
   }
 


### PR DESCRIPTION
## Summary
- document the end-to-end scripting lifecycle across server and client runtimes
- expand `app.control` docs and guidance for LOD and collision metadata exported from Blender
- add a clone helper for stage materials so scripts can duplicate configured materials

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebf63a3e28832da5209d20da95e133