### PR TITLE
Expand Docker deployment documentation

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,11 +1,41 @@
 # 🐳 Docker Deployment
 
-The project can be run using Docker. Make sure you have Docker installed on your system.
+This guide walks through running Hyperfy with Docker for local development and
+production-style deployments.
 
-1. Build the image and run the container:
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) 24+ (Docker Desktop or the
+  Docker Engine/CLI)
+- Optional: [Docker Compose](https://docs.docker.com/compose/) 2.20+ if you
+  prefer declarative configuration
+
+## 1. Prepare configuration
+
+Create your environment file before building the image:
 
 ```bash
-docker build -t hyperfydemo . && docker run -d -p 3000:3000 \
+cp .env.example .env
+# Edit .env with the values you need (domain, secrets, feature flags, etc.)
+```
+
+The runtime expects `DOMAIN`, `PORT`, `ASSETS_DIR`, and public URLs to be
+defined. These values can come either from the `.env` file you mount into the
+container or from `docker run -e` flags.
+
+## 2. Build the image
+
+```bash
+docker build -t hyperfy .
+```
+
+You only need to rebuild when dependencies or build tooling change. Code inside
+`src/` can be bind-mounted for live editing without rebuilding the image.
+
+## 3. Run the container
+
+```bash
+docker run -d -p 3000:3000 \
   -v "$(pwd)/src:/app/src" \
   -v "$(pwd)/world:/app/world" \
   -v "$(pwd)/.env:/app/.env" \
@@ -15,14 +45,82 @@ docker build -t hyperfydemo . && docker run -d -p 3000:3000 \
   -e PUBLIC_WS_URL=https://demo.hyperfy.host/ws \
   -e PUBLIC_API_URL=https://demo.hyperfy.host/api \
   -e PUBLIC_ASSETS_URL=https://demo.hyperfy.host/assets \
-  hyperfydemo
+  --name hyperfy \
+  hyperfy
 ```
 
 This command:
-- Builds the Docker image tagged as 'hyperfydemo'
-- Mounts local src/, world/ directories and .env file into the container
-- Exposes port 3000
-- Sets up required environment variables
-- Runs the container in detached mode (-d)
 
-Note: Adjust the URLs and domain according to your specific setup.
+- Runs Hyperfy in detached mode (`-d`) and maps the container’s port 3000 to the
+  host
+- Mounts local `src/`, `world/`, and `.env` files so code and content updates
+  are reflected immediately
+- Injects the key environment variables required for public access URLs
+
+Adjust the domain, ports, and URLs to match your deployment target. The
+`--name` flag makes it easier to stop or inspect the container later:
+
+```bash
+docker logs -f hyperfy
+docker stop hyperfy
+docker start hyperfy
+```
+
+## 4. Updating the running container
+
+If you change dependencies or the Dockerfile itself, rebuild and restart:
+
+```bash
+docker build -t hyperfy .
+docker stop hyperfy && docker rm hyperfy
+# then run the `docker run` command again
+```
+
+For source-only tweaks (JavaScript, assets) the bind mounts allow instant
+updates without a rebuild.
+
+## Optional: Docker Compose
+
+For more complex setups (databases, multiple services) you can use Docker
+Compose. Save the following as `docker-compose.yml` and adjust as needed:
+
+```yaml
+services:
+  hyperfy:
+    build: .
+    image: hyperfy
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    environment:
+      DOMAIN: demo.hyperfy.host
+      ASSETS_DIR: /world/assets
+      PUBLIC_WS_URL: https://demo.hyperfy.host/ws
+      PUBLIC_API_URL: https://demo.hyperfy.host/api
+      PUBLIC_ASSETS_URL: https://demo.hyperfy.host/assets
+    volumes:
+      - ./src:/app/src
+      - ./world:/app/world
+      - ./.env:/app/.env
+```
+
+Bring the stack up or down with:
+
+```bash
+docker compose up -d
+docker compose down
+```
+
+## Cleanup
+
+To reclaim disk space after experimenting:
+
+```bash
+docker stop hyperfy && docker rm hyperfy
+docker image rm hyperfy
+docker volume prune
+```
+
+The last command removes unused volumes. Skip it if you have other containers
+relying on named volumes.


### PR DESCRIPTION
## Summary
- expand the Docker deployment guide with clearer setup steps and runtime guidance
- add optional Docker Compose example and cleanup instructions

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ec12a3fd10832dbbe1bb6e5d575944