### PR TITLE
Streamline client panels and avatar preview cleanup

### DIFF
--- a/src/client/AvatarPreview.js
+++ b/src/client/AvatarPreview.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three'
-import { isString } from 'lodash'
 import { Emotes } from '../core/extras/playerEmotes'
 
 const MAX_UPLOAD_SIZE = 50 * 1024 * 1024
@@ -10,25 +9,7 @@ const PLANE_ASPECT_RATIO = 16 / 9
 const HDR_URL = '/day2.hdr'
 
 const DEG2RAD = THREE.MathUtils.DEG2RAD
-const RAD2DEG = THREE.MathUtils.RAD2DEG
-
 const v1 = new THREE.Vector3()
-const v2 = new THREE.Vector3()
-const v3 = new THREE.Vector3()
-
-const materialSlots = [
-  'alphaMap',
-  'aoMap',
-  'bumpMap',
-  'displacementMap',
-  'emissiveMap',
-  'envMap',
-  'lightMap',
-  'map',
-  'metalnessMap',
-  'normalMap',
-  'roughnessMap',
-]
 
 let renderer = null // re-use one renderer for this
 function getRenderer() {
@@ -76,7 +57,6 @@ export class AvatarPreview {
   async load(file, url) {
     this.file = file
     this.url = url
-    console.log('file', this.file)
     if (this.file.size > MAX_UPLOAD_SIZE) {
       return { error: `Max file size ${MAX_UPLOAD_SIZE_LABEL}` }
     }
@@ -185,9 +165,9 @@ export class AvatarPreview {
 
     const fov = camera.fov * (Math.PI / 180)
     const fovh = 2 * Math.atan(Math.tan(fov / 2) * camera.aspect)
-    let dx = size.z / 2 + Math.abs(size.x / 2 / Math.tan(fovh / 2))
-    let dy = size.z / 2 + Math.abs(size.y / 2 / Math.tan(fov / 2))
-    let cameraZ = Math.max(dx, dy)
+    const dx = size.z / 2 + Math.abs(size.x / 2 / Math.tan(fovh / 2))
+    const dy = size.z / 2 + Math.abs(size.y / 2 / Math.tan(fov / 2))
+    const cameraZ = Math.max(dx, dy)
 
     camera.position.z = -cameraZ
     camera.rotation.y += 180 * DEG2RAD
@@ -237,8 +217,6 @@ export class AvatarPreview {
   }
 
   resolveInfo() {
-    console.log(this.renderer.info)
-    console.log(this.renderer.info.render.triangles)
     const stats = {}
     // bounds
     const bbox = new THREE.Box3().setFromObject(this.node.instance.raw.scene)
@@ -315,7 +293,6 @@ export class AvatarPreview {
       rank,
       stats,
     }
-    console.log('info', this.info)
   }
 
   determineRank(fn) {

--- a/src/client/components/AppsList.js
+++ b/src/client/components/AppsList.js
@@ -1,17 +1,13 @@
 import { css } from '@firebolt-dev/css'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   BoxIcon,
   BrickWallIcon,
   CrosshairIcon,
-  EyeIcon,
-  EyeOffIcon,
   FileCode2Icon,
   HardDriveIcon,
   HashIcon,
   OctagonXIcon,
-  Rows3Icon,
-  SettingsIcon,
   TriangleIcon,
 } from 'lucide-react'
 
@@ -30,9 +26,11 @@ export function AppsList({ world, query, perf, refresh, setRefresh }) {
   const [sort, setSort] = useState('count')
   const [asc, setAsc] = useState(false)
   const [target, setTarget] = useState(null)
-  let items = useMemo(() => {
+  const items = useMemo(() => {
+    // Use refresh as a memo-buster when manual recomputation is requested.
+    void refresh
     const itemMap = new Map() // id -> { blueprint, count }
-    let items = []
+    const results = []
     for (const [_, entity] of world.entities.items) {
       if (!entity.isApp) continue
       const blueprint = world.blueprints.get(entity.data.blueprint)
@@ -40,7 +38,7 @@ export function AppsList({ world, query, perf, refresh, setRefresh }) {
       if (!blueprint.model) continue // corrupt app?
       let item = itemMap.get(blueprint.id)
       if (!item) {
-        let count = 0
+        const count = 0
         const type = blueprint.model.endsWith('.vrm') ? 'avatar' : 'model'
         const model = world.loader.get(type, blueprint.model)
         const stats = model?.getStats() || defaultStats
@@ -60,22 +58,22 @@ export function AppsList({ world, query, perf, refresh, setRefresh }) {
         }
         itemMap.set(blueprint.id, item)
       }
-      item.count++
+      item.count += 1
     }
     for (const [_, item] of itemMap) {
-      items.push(item)
+      results.push(item)
     }
-    return items
-  }, [refresh])
-  items = useMemo(() => {
+    return results
+  }, [refresh, world])
+  const normalizedQuery = query ? query.trim().toLowerCase() : ''
+  const filteredItems = useMemo(() => {
     let newItems = items
-    if (query) {
-      query = query.toLowerCase()
-      newItems = newItems.filter(item => item.keywords.includes(query))
+    if (normalizedQuery) {
+      newItems = newItems.filter(item => item.keywords.includes(normalizedQuery))
     }
     newItems = orderBy(newItems, sort, asc ? 'asc' : 'desc')
     return newItems
-  }, [items, sort, asc, query])
+  }, [items, sort, asc, normalizedQuery])
   useEffect(() => {
     function onChange() {
       setRefresh(n => n + 1)
@@ -86,7 +84,7 @@ export function AppsList({ world, query, perf, refresh, setRefresh }) {
       world.entities.off('added', onChange)
       world.entities.off('removed', onChange)
     }
-  }, [])
+  }, [setRefresh, world.entities])
   const reorder = key => {
     if (sort === key) {
       setAsc(!asc)
@@ -97,7 +95,7 @@ export function AppsList({ world, query, perf, refresh, setRefresh }) {
   }
   useEffect(() => {
     return () => world.target.hide()
-  }, [])
+  }, [world.target])
   const getClosest = item => {
     // find closest entity
     const playerPosition = world.rig.position
@@ -313,7 +311,7 @@ export function AppsList({ world, query, perf, refresh, setRefresh }) {
         <div className='appslist-headitem actions' />
       </div>
       <div className='appslist-rows'>
-        {items.map(item => (
+        {filteredItems.map(item => (
           <div key={item.blueprint.id} className='appslist-row'>
             <div className='appslist-rowitem name' onClick={() => inspect(item)}>
               <span>{item.name}</span>

--- a/src/client/components/AppsPane.js
+++ b/src/client/components/AppsPane.js
@@ -2,7 +2,6 @@ import { css } from '@firebolt-dev/css'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   BoxIcon,
-  BrickWall,
   BrickWallIcon,
   CrosshairIcon,
   EyeIcon,
@@ -10,15 +9,11 @@ import {
   FileCode2Icon,
   HardDriveIcon,
   HashIcon,
-  LayoutGridIcon,
-  PencilIcon,
   RotateCcwIcon,
   SearchIcon,
   SettingsIcon,
-  TargetIcon,
   TriangleIcon,
   XIcon,
-  ZapIcon,
 } from 'lucide-react'
 
 import { usePane } from './usePane'
@@ -106,16 +101,18 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
   const [sort, setSort] = useState('count')
   const [asc, setAsc] = useState(false)
   const [target, setTarget] = useState(null)
-  let items = useMemo(() => {
+  const items = useMemo(() => {
+    // Use refresh as a memo-buster when manual recomputation is requested.
+    void refresh
     const itemMap = new Map() // id -> { blueprint, count }
-    let items = []
+    const results = []
     for (const [_, entity] of world.entities.items) {
       if (!entity.isApp) continue
       const blueprint = entity.blueprint
       if (!blueprint) continue // still loading?
       let item = itemMap.get(blueprint.id)
       if (!item) {
-        let count = 0
+        const count = 0
         const type = blueprint.model.endsWith('.vrm') ? 'avatar' : 'model'
         const model = world.loader.get(type, blueprint.model)
         if (!model) continue
@@ -136,22 +133,22 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
         }
         itemMap.set(blueprint.id, item)
       }
-      item.count++
+      item.count += 1
     }
     for (const [_, item] of itemMap) {
-      items.push(item)
+      results.push(item)
     }
-    return items
-  }, [refresh])
-  items = useMemo(() => {
+    return results
+  }, [refresh, world])
+  const normalizedQuery = query ? query.trim().toLowerCase() : ''
+  const filteredItems = useMemo(() => {
     let newItems = items
-    if (query) {
-      query = query.toLowerCase()
-      newItems = newItems.filter(item => item.keywords.includes(query))
+    if (normalizedQuery) {
+      newItems = newItems.filter(item => item.keywords.includes(normalizedQuery))
     }
     newItems = orderBy(newItems, sort, asc ? 'asc' : 'desc')
     return newItems
-  }, [items, sort, asc, query])
+  }, [items, sort, asc, normalizedQuery])
   const reorder = key => {
     if (sort === key) {
       setAsc(!asc)
@@ -162,7 +159,7 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
   }
   useEffect(() => {
     return () => world.target.hide()
-  }, [])
+  }, [world.target])
   const getClosest = item => {
     // find closest entity
     const playerPosition = world.rig.position
@@ -362,7 +359,7 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
         <div className='asettings-headitem actions' />
       </div>
       <div className='asettings-rows noscrollbar'>
-        {items.map(item => (
+        {filteredItems.map(item => (
           <div key={item.blueprint.id} className='asettings-row'>
             <div className='asettings-rowitem name' onClick={() => target(item)}>
               <span>{item.name}</span>

--- a/src/client/components/AvatarPane.js
+++ b/src/client/components/AvatarPane.js
@@ -1,26 +1,35 @@
 import { css } from '@firebolt-dev/css'
 import { useEffect, useRef, useState } from 'react'
-import { UserIcon, XIcon } from 'lucide-react'
+import { XIcon } from 'lucide-react'
 
 import { usePane } from './usePane'
 import { AvatarPreview } from '../AvatarPreview'
+import { formatBytes } from '../../core/extras/formatBytes'
 
 export function AvatarPane({ world, info }) {
+  const paneRef = useRef()
+  const headRef = useRef()
   const viewportRef = useRef()
-  const previewRef = useRef()
-  const [stats, setStats] = useState(null)
+  const [previewInfo, setPreviewInfo] = useState(null)
+  usePane('avatar', paneRef, headRef)
   useEffect(() => {
     const viewport = viewportRef.current
+    if (!viewport) return undefined
     const preview = new AvatarPreview(world, viewport)
-    previewRef.current = preview
-    preview.load(info.file, info.url).then(stats => {
-      console.log('stats', stats)
-      setStats(stats)
+    let mounted = true
+    preview.load(info.file, info.url).then(result => {
+      if (mounted) {
+        setPreviewInfo(result)
+      }
     })
-    return () => preview.destroy()
-  }, [])
+    return () => {
+      mounted = false
+      preview.destroy()
+    }
+  }, [world, info.file, info.url])
   return (
     <div
+      ref={paneRef}
       className='vpane'
       css={css`
         position: absolute;
@@ -92,9 +101,55 @@ export function AvatarPane({ world, info }) {
             cursor: pointer;
           }
         }
+        .vpane-stats {
+          padding: 1rem;
+          border-top: 1px solid rgba(255, 255, 255, 0.05);
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+        }
+        .vpane-rank {
+          display: flex;
+          align-items: baseline;
+          gap: 0.5rem;
+          font-weight: 500;
+        }
+        .vpane-rank-badge {
+          font-size: 0.8125rem;
+          padding: 0.2rem 0.5rem;
+          border-radius: 999px;
+          background: rgba(255, 255, 255, 0.08);
+        }
+        .vpane-statlist {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 0.75rem 0.5rem;
+          font-size: 0.875rem;
+        }
+        .vpane-stat {
+          display: flex;
+          flex-direction: column;
+          gap: 0.25rem;
+        }
+        .vpane-stat-label {
+          color: rgba(255, 255, 255, 0.65);
+          font-size: 0.75rem;
+          letter-spacing: 0.02em;
+          text-transform: uppercase;
+        }
+        .vpane-stat-value {
+          display: flex;
+          align-items: center;
+          gap: 0.25rem;
+          font-weight: 500;
+        }
+        .vpane-stat-rank {
+          font-size: 0.75rem;
+          color: rgba(255, 255, 255, 0.5);
+        }
       `}
     >
-      <div className='vpane-head'>
+      <div className='vpane-head' ref={headRef}>
         <div className='vpane-head-title'>Avatar</div>
         <div className='vpane-head-close' onClick={() => world.emit('avatar', null)}>
           <XIcon size={20} />
@@ -104,6 +159,7 @@ export function AvatarPane({ world, info }) {
         <div className='vpane-viewport'>
           <div className='vpane-viewport-inner' ref={viewportRef}></div>
         </div>
+        {previewInfo && <AvatarStats info={previewInfo} />}
         <div className='vpane-actions'>
           <div className='vpane-action' onClick={info.onEquip}>
             <span>Equip</span>
@@ -114,6 +170,48 @@ export function AvatarPane({ world, info }) {
             </div>
           )}
         </div>
+      </div>
+    </div>
+  )
+}
+
+const rankLabels = {
+  5: 'Perfect',
+  4: 'Great',
+  3: 'Good',
+  2: 'Heavy',
+  1: 'Very Poor',
+}
+
+const statDescriptors = [
+  { key: 'bounds', label: 'Bounds', format: value => value.map(size => `${size}m`).join(' × ') },
+  { key: 'triangles', label: 'Triangles', format: value => value.toLocaleString() },
+  { key: 'draws', label: 'Draw Calls', format: value => value.toLocaleString() },
+  { key: 'bones', label: 'Bones', format: value => value.toLocaleString() },
+  { key: 'fileSize', label: 'File Size', format: value => formatBytes(value) },
+]
+
+function AvatarStats({ info }) {
+  return (
+    <div className='vpane-stats'>
+      <div className='vpane-rank'>
+        <span>{rankLabels[info.rank] || 'Unranked'}</span>
+        <span className='vpane-rank-badge'>Rank {info.rank}</span>
+      </div>
+      <div className='vpane-statlist'>
+        {statDescriptors.map(descriptor => {
+          const stat = info.stats[descriptor.key]
+          if (!stat) return null
+          return (
+            <div key={descriptor.key} className='vpane-stat'>
+              <span className='vpane-stat-label'>{descriptor.label}</span>
+              <span className='vpane-stat-value'>
+                {descriptor.format(stat.value)}
+                <span className='vpane-stat-rank'>≥ Rank {stat.rank}</span>
+              </span>
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/client/components/CoreUI.js
+++ b/src/client/components/CoreUI.js
@@ -1,17 +1,13 @@
 import { css } from '@firebolt-dev/css'
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronUpIcon, LoaderIcon, MessageSquareTextIcon, RefreshCwIcon, SendHorizonalIcon } from 'lucide-react'
-import moment from 'moment'
+import { useEffect, useRef, useState } from 'react'
+import { MessageSquareTextIcon, RefreshCwIcon, SendHorizonalIcon } from 'lucide-react'
 
-// import { CodeEditor } from './CodeEditor'
 import { AvatarPane } from './AvatarPane'
-import { useElemSize } from './useElemSize'
 import { MouseLeftIcon } from './MouseLeftIcon'
 import { MouseRightIcon } from './MouseRightIcon'
 import { MouseWheelIcon } from './MouseWheelIcon'
 import { buttons, propToLabel } from '../../core/extras/buttons'
 import { cls, isTouch } from '../utils'
-import { uuid } from '../../core/utils'
 import { ControlPriorities } from '../../core/extras/ControlPriorities'
 // import { AppsPane } from './AppsPane'
 // import { MenuMain } from './MenuMain'
@@ -22,24 +18,16 @@ import { Sidebar } from './Sidebar'
 export function CoreUI({ world }) {
   const ref = useRef()
   const [ready, setReady] = useState(false)
-  const [player, setPlayer] = useState(() => world.entities.player)
   const [ui, setUI] = useState(world.ui.state)
-  const [menu, setMenu] = useState(null)
   const [confirm, setConfirm] = useState(null)
-  const [code, setCode] = useState(false)
   const [avatar, setAvatar] = useState(null)
   const [disconnected, setDisconnected] = useState(false)
-  const [apps, setApps] = useState(false)
   const [kicked, setKicked] = useState(null)
   const [appControl, setAppControl] = useState(null)
   useEffect(() => {
     world.on('ready', setReady)
-    world.on('player', setPlayer)
     world.on('ui', setUI)
-    world.on('menu', setMenu)
     world.on('confirm', setConfirm)
-    world.on('code', setCode)
-    world.on('apps', setApps)
     world.on('avatar', setAvatar)
     world.on('kick', setKicked)
     world.on('disconnect', setDisconnected)
@@ -62,12 +50,8 @@ export function CoreUI({ world }) {
     world.on('app-control', onAppControl)
     return () => {
       world.off('ready', setReady)
-      world.off('player', setPlayer)
       world.off('ui', setUI)
-      world.off('menu', setMenu)
       world.off('confirm', setConfirm)
-      world.off('code', setCode)
-      world.off('apps', setApps)
       world.off('avatar', setAvatar)
       world.off('kick', setKicked)
       world.off('disconnect', setDisconnected)
@@ -176,8 +160,7 @@ function AppControlBanner({ world, info }) {
       `}
     >
       <span>
-        {info.name} is using your input.{' '}
-        <strong>Release control</strong> when you are finished.
+        {info.name} is using your input. <strong>Release control</strong> when you are finished.
       </span>
       <button type='button' onClick={release}>
         Release
@@ -596,26 +579,14 @@ function MiniMessages({ world }) {
   return <Message msg={msg} />
 }
 
-const MESSAGES_REFRESH_RATE = 30 // every x seconds
-
 function Messages({ world, active }) {
   const initRef = useRef()
   const contentRef = useRef()
   const spacerRef = useRef()
-  // const [now, setNow] = useState(() => moment())
   const [msgs, setMsgs] = useState([])
   useEffect(() => {
     return world.chat.subscribe(setMsgs)
   }, [])
-  // useEffect(() => {
-  //   let timerId
-  //   const updateNow = () => {
-  //     setNow(moment())
-  //     timerId = setTimeout(updateNow, MESSAGES_REFRESH_RATE * 1000)
-  //   }
-  //   timerId = setTimeout(updateNow, MESSAGES_REFRESH_RATE * 1000)
-  //   return () => clearTimeout(timerId)
-  // }, [])
   useEffect(() => {
     if (!msgs.length) return
     const didInit = !initRef.current
@@ -671,27 +642,13 @@ function Messages({ world, active }) {
     >
       <div className='messages-spacer' ref={spacerRef} />
       {msgs.map(msg => (
-        <Message key={msg.id} msg={msg} /*now={now}*/ />
+        <Message key={msg.id} msg={msg} />
       ))}
     </div>
   )
 }
 
-function Message({ msg, now }) {
-  // const timeAgo = useMemo(() => {
-  //   const createdAt = moment(msg.createdAt)
-  //   const age = now.diff(createdAt, 'seconds')
-  //   // up to 10s ago show now
-  //   if (age < 10) return 'now'
-  //   // under a minute show seconds
-  //   if (age < 60) return `${age}s ago`
-  //   // under an hour show minutes
-  //   if (age < 3600) return Math.floor(age / 60) + 'm ago'
-  //   // under a day show hours
-  //   if (age < 86400) return Math.floor(age / 3600) + 'h ago'
-  //   // otherwise show days
-  //   return Math.floor(age / 86400) + 'd ago'
-  // }, [now])
+function Message({ msg }) {
   return (
     <div
       className='message'

--- a/src/client/components/MenuApp.js
+++ b/src/client/components/MenuApp.js
@@ -97,9 +97,7 @@ function MenuAppIndex({ world, app, blueprint, frozen, pop, push }) {
   }
   return (
     <>
-      {frozen && (
-        <MenuSection label='This blueprint is frozen. Duplicate it to make changes.' />
-      )}
+      {frozen && <MenuSection label='This blueprint is frozen. Duplicate it to make changes.' />}
       <MenuItemFields world={world} app={app} blueprint={blueprint} frozen={frozen} />
       {app.fields?.length > 0 && !frozen && <MenuLine />}
       {!frozen && (
@@ -177,13 +175,7 @@ function MenuItemField({ world, props, field, value, modify, frozen }) {
     return <MenuSection label={field.label} />
   }
   if (frozen) {
-    return (
-      <MenuItemStatic
-        label={field.label}
-        hint={field.hint}
-        value={formatFieldValue(field, value, props)}
-      />
-    )
+    return <MenuItemStatic label={field.label} hint={field.hint} value={formatFieldValue(field, value, props)} />
   }
   if (field.type === 'text') {
     return (
@@ -340,8 +332,16 @@ function MenuAppFlags({ world, app, blueprint, frozen, pop, push }) {
     return (
       <>
         <MenuItemBack hint='Go back to the main app details' onClick={pop} />
-        <MenuItemStatic label='Preload' hint='Preload this app before players enter the world' value={blueprint.preload ? 'Enabled' : 'Disabled'} />
-        <MenuItemStatic label='Lock' hint='Lock the app so that edits are disabled' value={blueprint.locked ? 'Enabled' : 'Disabled'} />
+        <MenuItemStatic
+          label='Preload'
+          hint='Preload this app before players enter the world'
+          value={blueprint.preload ? 'Enabled' : 'Disabled'}
+        />
+        <MenuItemStatic
+          label='Lock'
+          hint='Lock the app so that edits are disabled'
+          value={blueprint.locked ? 'Enabled' : 'Disabled'}
+        />
         <MenuItemStatic
           label='Unique'
           hint='When duplicating this app in the world, create a completely new and unique instance with its own separate config'
@@ -388,7 +388,11 @@ function MenuAppMetadata({ world, app, blueprint, frozen, pop, push }) {
         <MenuItemBack hint='Go back to the main app details' onClick={pop} />
         <MenuItemStatic label='Name' hint='The name of this app' value={blueprint.name} />
         <MenuItemStatic label='Image' hint='An image/icon for this app' value={blueprint.image?.url || '—'} />
-        <MenuItemStatic label='Author' hint='The name of the author that made this app' value={blueprint.author || '—'} />
+        <MenuItemStatic
+          label='Author'
+          hint='The name of the author that made this app'
+          value={blueprint.author || '—'}
+        />
         <MenuItemStatic label='URL' hint='A url for this app' value={blueprint.url || '—'} />
         <MenuItemStatic label='Description' hint='A description for this app' value={blueprint.desc || '—'} />
       </>


### PR DESCRIPTION
## Summary
- refactor the apps list and pane to memoize computed data safely and drop unused icons
- enhance the avatar pane by wiring drag persistence and surfacing preview stats in the UI
- remove unused helpers and logging from the avatar preview and trim dead code paths in the core UI, plus format the app menu

## Testing
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68f28508e570832d871f231ab0ee2a60