### PR TITLE
Add CI workflow for lint and build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.11.0
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint and formatting checks
+        run: npm run check
+
+      - name: Build project
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hyperfy ⚡️
 
+[![CI](https://github.com/hyperfy-xyz/hyperfy/actions/workflows/ci.yml/badge.svg)](https://github.com/hyperfy-xyz/hyperfy/actions/workflows/ci.yml)
+
 <div align="center">
   <img src="overview.png" alt="Hyperfy Ecosystem" width="100%" />
   <p>


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies, runs npm check, and builds the project
- surface the workflow status in the README with a CI badge for quick visibility

## Testing
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f289436314832d9f8a29369f1561d3