### PR TITLE
Add theme controls, modern panes, and UI telemetry

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,4 +22,14 @@ Sets your player name.
 
 ### `/chat clear`
 
-Clears all chat messages. Requires builder rank. 
+Clears all chat messages. Requires builder rank.
+
+## Keyboard shortcuts
+
+You can navigate the refreshed interface without leaving the keyboard:
+
+* `Esc` — close the active pane or reopen the main menu when nothing else is focused.
+* `Ctrl`/`Cmd` + `Shift` + `P` — toggle the main menu from anywhere in the world.
+* `Ctrl`/`Cmd` + `Shift` + `A` — open or close the apps pane (builder access required to manage apps).
+* `Shift` + `?` — jump directly to the help and shortcuts page inside the main menu.
+* `Tab` / `Shift` + `Tab` — move between focusable controls when a menu or pane is open.

--- a/docs/extras/ui-telemetry.md
+++ b/docs/extras/ui-telemetry.md
@@ -1,0 +1,23 @@
+# UI Telemetry and Preferences
+
+The client now records lightweight telemetry so you can gauge how responsive the UI feels when players tweak their settings. All events are stored in `world.telemetry.entries` while the session is active, making them easy to inspect from the developer console (`world.telemetry.entries.at(-1)` shows the latest entry).
+
+## Event catalogue
+
+* `theme-applied` — fired after the active theme variables have been written to the document. Includes the resolved theme mode (`dark`, `light`, or `system`) and the time in milliseconds between the preference change and the browser painting a new frame.
+* `prefs-change-applied` — emitted once UI-related preferences (scale, actions, theme hues, etc.) propagate through the React layer. The payload lists the unique preference keys that changed during the animation frame and the duration required for React to commit the update.
+* `persisted` — produced by `ClientPrefs` after the two-second safety delay when values are flushed to local storage. The snapshot contains the persisted theme settings alongside the duration of the write.
+
+You can clear the rolling telemetry buffer manually by reassigning `world.telemetry.entries.length = 0` if you want a fresh capture during profiling.
+
+## Theme preferences
+
+Theme-related preferences now live alongside the existing UI scale and graphics options:
+
+* `world.prefs.themeMode` (`dark`, `light`, or `system`)
+* `world.prefs.themeHuePrimary` (accent hue in degrees)
+* `world.prefs.themeHueNeutral` (base surface hue in degrees)
+
+They are persisted automatically and can be modified from the **Menu → UI → Appearance** section or programmatically by calling `world.prefs.setThemeMode`/`setThemeHuePrimary`/`setThemeHueNeutral`.
+
+When the theme mode is set to `system`, the client listens for `prefers-color-scheme` changes and reapplies tokens on the fly, which also surfaces in the telemetry stream via `theme-applied` events.

--- a/src/client/components/AppsPane.js
+++ b/src/client/components/AppsPane.js
@@ -20,11 +20,16 @@ import { usePane } from './usePane'
 import { cls } from './cls'
 import { orderBy } from 'lodash-es'
 import { formatBytes } from '../../core/extras/formatBytes'
+import { useFocusTrap } from './useFocusTrap'
+import { useRank } from './useRank'
 
-export function AppsPane({ world, close }) {
+export function AppsPane({ world, close, visible = true }) {
   const paneRef = useRef()
   const headRef = useRef()
   usePane('apps', paneRef, headRef)
+  useFocusTrap(paneRef, { active: visible })
+  const player = world.entities.player
+  const { isBuilder } = useRank(world, player)
   const [query, setQuery] = useState('')
   const [refresh, setRefresh] = useState(0)
   return (
@@ -33,20 +38,27 @@ export function AppsPane({ world, close }) {
       className='apane'
       css={css`
         position: absolute;
-        top: 20px;
-        left: 20px;
-        width: 38rem;
-        background-color: rgba(15, 16, 24, 0.8);
+        top: 0;
+        left: 0;
+        width: min(40rem, calc(100vw - 4rem));
+        background-color: var(--hf-color-surface);
         pointer-events: auto;
         display: flex;
         flex-direction: column;
         font-size: 1rem;
+        border: 1px solid var(--hf-color-border);
+        border-radius: 1rem;
+        box-shadow: var(--hf-shadow-soft);
+        color: var(--hf-color-text);
+        opacity: ${visible ? 1 : 0};
+        transform: translateY(${visible ? '0' : '12px'});
+        transition: opacity 200ms ease, transform 200ms ease;
         .apane-head {
           height: 3.125rem;
-          background: black;
+          background: var(--hf-color-surface-raised);
           display: flex;
           align-items: center;
-          padding: 0 0.8125rem 0 1.25rem;
+          padding: 0 1.25rem;
           &-title {
             font-size: 1.2rem;
             font-weight: 500;
@@ -70,34 +82,53 @@ export function AppsPane({ world, close }) {
             display: flex;
             align-items: center;
             justify-content: center;
-            color: rgba(255, 255, 255, 0.5);
+            color: var(--hf-color-text-muted);
+            background: none;
+            border: none;
             &:hover {
               cursor: pointer;
-              color: white;
+              color: var(--hf-color-heading);
             }
           }
         }
       `}
+      role='dialog'
+      aria-modal='true'
+      aria-label='Apps'
+      aria-hidden={!visible}
+      tabIndex={-1}
     >
       <div className='apane-head' ref={headRef}>
         <div className='apane-head-title'>Apps</div>
         <div className='apane-head-search'>
           <SearchIcon size={16} />
-          <input type='text' placeholder='Search' value={query} onChange={e => setQuery(e.target.value)} />
+          <input
+            type='text'
+            placeholder='Search apps'
+            aria-label='Search apps'
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+          />
         </div>
-        <div className='apane-head-btn' onClick={() => setRefresh(n => n + 1)}>
+        <button className='apane-head-btn' type='button' onClick={() => setRefresh(n => n + 1)} aria-label='Refresh list'>
           <RotateCcwIcon size={16} />
-        </div>
-        <div className='apane-head-btn' onClick={close}>
+        </button>
+        <button className='apane-head-btn' type='button' onClick={close} aria-label='Close apps pane'>
           <XIcon size={20} />
-        </div>
+        </button>
       </div>
-      <AppsPaneContent world={world} query={query} refresh={refresh} setRefresh={setRefresh} />
+      <AppsPaneContent
+        world={world}
+        query={query}
+        refresh={refresh}
+        setRefresh={setRefresh}
+        isBuilder={isBuilder}
+      />
     </div>
   )
 }
 
-function AppsPaneContent({ world, query, refresh, setRefresh }) {
+function AppsPaneContent({ world, query, refresh, setRefresh, isBuilder }) {
   const [sort, setSort] = useState('count')
   const [asc, setAsc] = useState(false)
   const [activeItem, setActiveItem] = useState(null)
@@ -177,6 +208,15 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
     return closestEntity
   }
   const toggleTarget = item => {
+    if (!isBuilder) {
+      const message =
+        world.ui?.getLocalizedString?.(
+          'ui.apps.highlight.buildersOnly',
+          'Highlighting apps is available to builders only.'
+        ) || 'Highlighting apps is available to builders only.'
+      world.emit('toast', message)
+      return
+    }
     if (activeItem === item) {
       world.target.hide()
       setActiveItem(null)
@@ -189,8 +229,9 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
   }
   const inspect = item => {
     const entity = getClosest(item)
-    world.ui.setApp(entity)
-    // world.ui.setMenu({ type: 'app', app: entity })
+    if (!entity) return
+    world.ui.toggleApps(false)
+    world.ui.setMenu({ type: 'app', app: entity })
   }
   const toggle = item => {
     const blueprint = world.blueprints.get(item.blueprint.id)
@@ -212,6 +253,9 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
           display: flex;
           align-items: center;
           margin: 0 0 0.3125rem;
+          background: var(--hf-color-surface);
+          border-bottom: 1px solid var(--hf-color-border);
+          padding-bottom: 0.5rem;
         }
         .asettings-headitem {
           font-size: 1rem;
@@ -219,8 +263,17 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
           white-space: nowrap;
           text-overflow: ellipsis;
           overflow: hidden;
+          color: var(--hf-color-text-muted);
+          background: none;
+          border: none;
+          display: flex;
+          align-items: center;
+          justify-content: flex-end;
+          padding: 0;
+          height: 2rem;
           &.name {
             flex: 1;
+            justify-content: flex-start;
           }
           &.code {
             width: 3rem;
@@ -243,9 +296,10 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
           }
           &:hover:not(.active) {
             cursor: pointer;
+            color: var(--hf-color-heading);
           }
           &.active {
-            color: #4088ff;
+            color: var(--hf-color-primary);
           }
         }
         .asettings-rows {
@@ -257,13 +311,19 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
           display: flex;
           align-items: center;
           margin: 0 0 0.3125rem;
+          border-radius: 0.4rem;
+          &:hover {
+            background: var(--hf-color-surface-hover);
+          }
         }
         .asettings-rowitem {
           font-size: 1rem;
-          color: rgba(255, 255, 255, 0.8);
+          color: var(--hf-color-text);
           white-space: nowrap;
           text-overflow: ellipsis;
           overflow: hidden;
+          display: flex;
+          align-items: center;
           &.name {
             flex: 1;
           }
@@ -290,9 +350,15 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
         }
         .asettings-action {
           margin-left: 0.625rem;
-          color: rgba(255, 255, 255, 0.4);
+          color: var(--hf-color-text-muted);
+          background: none;
+          border: none;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          padding: 0;
           &.active {
-            color: #4088ff;
+            color: var(--hf-color-primary);
           }
           &.red {
             color: #fb4848;
@@ -301,67 +367,85 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
             cursor: pointer;
           }
           &:hover:not(.active):not(.red) {
-            color: white;
+            color: var(--hf-color-heading);
           }
         }
       `}
     >
       <div className='asettings-head'>
-        <div
+        <button
+          type='button'
           className={cls('asettings-headitem name', { active: sort === 'name' })}
           onClick={() => reorder('name')}
           title='Name'
         >
           <span>Name</span>
-        </div>
-        <div
+        </button>
+        <button
+          type='button'
           className={cls('asettings-headitem count', { active: sort === 'count' })}
           onClick={() => reorder('count')}
           title='Instances'
         >
           <HashIcon size={16} />
-        </div>
-        <div
+        </button>
+        <button
+          type='button'
           className={cls('asettings-headitem geometries', { active: sort === 'geometries' })}
           onClick={() => reorder('geometries')}
           title='Geometries'
         >
           <BoxIcon size={16} />
-        </div>
-        <div
+        </button>
+        <button
+          type='button'
           className={cls('asettings-headitem triangles', { active: sort === 'triangles' })}
           onClick={() => reorder('triangles')}
           title='Triangles'
         >
           <TriangleIcon size={16} />
-        </div>
-        <div
+        </button>
+        <button
+          type='button'
           className={cls('asettings-headitem textureSize', { active: sort === 'textureBytes' })}
           onClick={() => reorder('textureBytes')}
           title='Texture Memory Size'
         >
           <BrickWallIcon size={16} />
-        </div>
-        <div
+        </button>
+        <button
+          type='button'
           className={cls('asettings-headitem code', { active: sort === 'code' })}
           onClick={() => reorder('code')}
           title='Code'
         >
           <FileCode2Icon size={16} />
-        </div>
-        <div
+        </button>
+        <button
+          type='button'
           className={cls('asettings-headitem fileSize', { active: sort === 'fileBytes' })}
           onClick={() => reorder('fileBytes')}
           title='File Size'
         >
           <HardDriveIcon size={16} />
-        </div>
-        <div className='asettings-headitem actions' />
+        </button>
+        <div className='asettings-headitem actions' aria-hidden='true' />
       </div>
       <div className='asettings-rows noscrollbar'>
         {filteredItems.map(item => (
           <div key={item.blueprint.id} className='asettings-row'>
-            <div className='asettings-rowitem name' onClick={() => toggleTarget(item)}>
+            <div
+              className='asettings-rowitem name'
+              role='button'
+              tabIndex={0}
+              onClick={() => toggleTarget(item)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  toggleTarget(item)
+                }
+              }}
+            >
               <span>{item.name}</span>
             </div>
             <div className='asettings-rowitem count'>
@@ -383,18 +467,30 @@ function AppsPaneContent({ world, query, refresh, setRefresh }) {
               <span>{item.fileSize}</span>
             </div>
             <div className={'asettings-rowitem actions'}>
-              <div className={cls('asettings-action', { red: item.blueprint.disabled })} onClick={() => toggle(item)}>
+              <button
+                type='button'
+                className={cls('asettings-action', { red: item.blueprint.disabled })}
+                onClick={() => toggle(item)}
+                aria-label={item.blueprint.disabled ? 'Enable app' : 'Disable app'}
+              >
                 {item.blueprint.disabled ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
-              </div>
-              <div
+              </button>
+              <button
+                type='button'
                 className={cls('asettings-action', { active: activeItem === item })}
                 onClick={() => toggleTarget(item)}
+                aria-label='Highlight nearest instance'
               >
                 <CrosshairIcon size={16} />
-              </div>
-              <div className={'asettings-action'} onClick={() => inspect(item)}>
+              </button>
+              <button
+                type='button'
+                className={'asettings-action'}
+                onClick={() => inspect(item)}
+                aria-label='Inspect app'
+              >
                 <SettingsIcon size={16} />
-              </div>
+              </button>
             </div>
           </div>
         ))}

--- a/src/client/components/CoreUI.js
+++ b/src/client/components/CoreUI.js
@@ -1,5 +1,5 @@
 import { css } from '@firebolt-dev/css'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { MessageSquareTextIcon, RefreshCwIcon, SendHorizonalIcon } from 'lucide-react'
 
 import { AvatarPane } from './AvatarPane'
@@ -9,11 +9,12 @@ import { MouseWheelIcon } from './MouseWheelIcon'
 import { buttons, propToLabel } from '../../core/extras/buttons'
 import { cls, isTouch } from '../utils'
 import { ControlPriorities } from '../../core/extras/ControlPriorities'
-// import { AppsPane } from './AppsPane'
-// import { MenuMain } from './MenuMain'
-// import { MenuApp } from './MenuApp'
+import { AppsPane } from './AppsPane'
+import { MenuMain } from './MenuMain'
+import { MenuApp } from './MenuApp'
 import { ChevronDoubleUpIcon, HandIcon } from './Icons'
 import { Sidebar } from './Sidebar'
+import { applyThemeFromPrefs, watchSystemTheme } from './theme'
 
 export function CoreUI({ world }) {
   const ref = useRef()
@@ -24,6 +25,38 @@ export function CoreUI({ world }) {
   const [disconnected, setDisconnected] = useState(false)
   const [kicked, setKicked] = useState(null)
   const [appControl, setAppControl] = useState(null)
+  const [appsMounted, setAppsMounted] = useState(() => world.ui.state.apps ?? false)
+  const [menuMounted, setMenuMounted] = useState(() => Boolean(world.ui.state.menu))
+  const queuePrefTelemetry = useMemo(() => {
+    let pendingKeys = new Set()
+    let scheduled = false
+    let frameStart = 0
+    return keys => {
+      if (Array.isArray(keys)) {
+        for (const key of keys) {
+          if (key) pendingKeys.add(key)
+        }
+      } else if (keys) {
+        pendingKeys.add(keys)
+      }
+      if (scheduled) return
+      scheduled = true
+      frameStart = performance.now()
+      requestAnimationFrame(() => {
+        const duration = performance.now() - frameStart
+        const payload = Array.from(pendingKeys)
+        pendingKeys = new Set()
+        scheduled = false
+        if (!payload.length) return
+        world.emit('telemetry', {
+          source: 'ui',
+          event: 'prefs-change-applied',
+          keys: payload,
+          duration,
+        })
+      })
+    }
+  }, [world])
   useEffect(() => {
     world.on('ready', setReady)
     world.on('ui', setUI)
@@ -60,6 +93,24 @@ export function CoreUI({ world }) {
   }, [])
 
   useEffect(() => {
+    if (ui.apps) {
+      setAppsMounted(true)
+      return
+    }
+    const timeout = setTimeout(() => setAppsMounted(false), 220)
+    return () => clearTimeout(timeout)
+  }, [ui.apps])
+
+  useEffect(() => {
+    if (ui.menu) {
+      setMenuMounted(true)
+      return
+    }
+    const timeout = setTimeout(() => setMenuMounted(false), 220)
+    return () => clearTimeout(timeout)
+  }, [ui.menu])
+
+  useEffect(() => {
     const elem = ref.current
     const onEvent = e => {
       e.isCoreUI = true
@@ -74,17 +125,72 @@ export function CoreUI({ world }) {
     // elem.addEventListener('touchend', onEvent)
   }, [])
   useEffect(() => {
-    document.documentElement.style.fontSize = `${16 * world.prefs.ui}px`
+    const applyScale = () => {
+      document.documentElement.style.fontSize = `${16 * world.prefs.ui}px`
+    }
+    applyScale()
     function onChange(changes) {
+      const keys = Object.keys(changes)
       if (changes.ui) {
-        document.documentElement.style.fontSize = `${16 * world.prefs.ui}px`
+        applyScale()
+      }
+      if (keys.length) {
+        queuePrefTelemetry(keys)
       }
     }
     world.prefs.on('change', onChange)
     return () => {
       world.prefs.off('change', onChange)
     }
-  }, [])
+  }, [world, queuePrefTelemetry])
+
+  useEffect(() => {
+    const applyTheme = () => {
+      const start = performance.now()
+      const { themeMode } = applyThemeFromPrefs(world.prefs)
+      requestAnimationFrame(() => {
+        const duration = performance.now() - start
+        world.emit('telemetry', {
+          source: 'ui',
+          event: 'theme-applied',
+          mode: themeMode,
+          duration,
+        })
+      })
+    }
+    applyTheme()
+    const onChange = changes => {
+      if (changes.themeMode || changes.themeHuePrimary || changes.themeHueNeutral) {
+        applyTheme()
+      }
+    }
+    const offSystem = watchSystemTheme(() => {
+      if (world.prefs.themeMode === 'system') {
+        applyTheme()
+      }
+    })
+    world.prefs.on('change', onChange)
+    return () => {
+      world.prefs.off('change', onChange)
+      offSystem()
+    }
+  }, [world])
+
+  useEffect(() => {
+    const entries = []
+    const onTelemetry = payload => {
+      entries.push({ timestamp: Date.now(), ...payload })
+      if (entries.length > 250) {
+        entries.shift()
+      }
+    }
+    world.on('telemetry', onTelemetry)
+    world.telemetry = { entries }
+    return () => {
+      world.off('telemetry', onTelemetry)
+      delete world.telemetry
+    }
+  }, [world])
   return (
     <div
       ref={ref}
@@ -106,13 +212,86 @@ export function CoreUI({ world }) {
         <CodeEditor key={`code-${menu.app.data.id}`} world={world} app={menu.app} blur={menu.blur} />
       )} */}
       {avatar && <AvatarPane key={avatar.hash} world={world} info={avatar} />}
-      {/* {apps && <AppsPane world={world} close={() => world.ui.toggleApps()} />} */}
+      {appsMounted && (
+        <div
+          className='coreui-appspane'
+          css={css`
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: flex-start;
+            justify-content: flex-start;
+            padding: calc(1.5rem + env(safe-area-inset-top)) calc(1.5rem + env(safe-area-inset-right))
+              calc(1.5rem + env(safe-area-inset-bottom)) calc(1.5rem + env(safe-area-inset-left));
+            pointer-events: ${ui.apps ? 'auto' : 'none'};
+            transition: opacity 200ms ease;
+            opacity: ${ui.apps ? 1 : 0};
+            z-index: 4;
+          `}
+          aria-hidden={!ui.apps}
+          onMouseDown={event => {
+            if (event.target === event.currentTarget) {
+              world.ui.toggleApps(false)
+            }
+          }}
+        >
+          <AppsPane world={world} close={() => world.ui.toggleApps(false)} visible={ui.apps} />
+        </div>
+      )}
       {!ready && <LoadingOverlay world={world} />}
       {kicked && <KickedOverlay code={kicked} />}
       {ready && isTouch && <TouchBtns world={world} />}
       {ready && isTouch && <TouchStick world={world} />}
       {confirm && <Confirm options={confirm} />}
       {ready && appControl && <AppControlBanner world={world} info={appControl} />}
+      {menuMounted && (
+        <div
+          className='coreui-menu'
+          css={css`
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            pointer-events: ${ui.menu ? 'auto' : 'none'};
+            z-index: 6;
+          `}
+          aria-hidden={!ui.menu}
+          onMouseDown={event => {
+            if (event.target === event.currentTarget) {
+              world.ui.setMenu(null)
+            }
+          }}
+        >
+          <div
+            css={css`
+              position: absolute;
+              inset: 0;
+              background: ${ui.menu ? 'rgba(4, 6, 11, 0.62)' : 'rgba(4, 6, 11, 0)'};
+              backdrop-filter: blur(${ui.menu ? '16px' : '0px'});
+              transition: opacity 220ms ease, backdrop-filter 220ms ease;
+              opacity: ${ui.menu ? 1 : 0};
+              pointer-events: none;
+            `}
+          />
+          <div
+            css={css`
+              position: relative;
+              pointer-events: auto;
+              opacity: ${ui.menu ? 1 : 0};
+              transform: translateY(${ui.menu ? '0' : '8px'});
+              transition: opacity 220ms ease, transform 220ms ease;
+              max-height: calc(100% - 4rem);
+              max-width: min(42rem, calc(100% - 4rem));
+            `}
+          >
+            {ui.menu?.type === 'main' && <MenuMain world={world} page={ui.menu.page} />}
+            {ui.menu?.type === 'app' && ui.menu.app && (
+              <MenuApp world={world} app={ui.menu.app} blur={ui.menu.blur} />
+            )}
+          </div>
+        </div>
+      )}
       <div id='core-ui-portal' />
     </div>
   )
@@ -135,13 +314,13 @@ function AppControlBanner({ world, info }) {
         align-items: center;
         gap: 0.75rem;
         padding: 0.75rem 1.25rem;
-        background: rgba(11, 10, 21, 0.9);
-        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: var(--hf-color-surface-raised);
+        border: 1px solid var(--hf-color-border);
         border-radius: 999px;
         pointer-events: auto;
-        box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.35);
+        box-shadow: var(--hf-shadow-soft);
         font-size: 0.95rem;
-        color: white;
+        color: var(--hf-color-text);
         button {
           pointer-events: auto;
           border: none;
@@ -149,12 +328,13 @@ function AppControlBanner({ world, info }) {
           padding: 0.4rem 0.9rem;
           font-size: 0.9rem;
           font-weight: 500;
-          background: rgba(255, 255, 255, 0.15);
-          color: white;
-          transition: background 0.15s ease;
+          background: var(--hf-color-primary-soft);
+          color: var(--hf-color-heading);
+          transition: background 0.15s ease, color 0.15s ease;
           &:hover {
             cursor: pointer;
-            background: rgba(255, 255, 255, 0.25);
+            background: var(--hf-color-primary);
+            color: hsl(0 0% 100%);
           }
         }
       `}

--- a/src/client/components/Menu.js
+++ b/src/client/components/Menu.js
@@ -9,37 +9,60 @@ import { CurvePreview } from './CurvePreview'
 import { Curve } from '../../core/extras/Curve'
 import { Portal } from './Portal'
 import { CurvePane } from './CurvePane'
+import { useFocusTrap } from './useFocusTrap'
 
 const MenuContext = createContext()
 
 export function Menu({ title, blur, children }) {
   const [hint, setHint] = useState(null)
+  const menuRef = useRef(null)
+  useFocusTrap(menuRef)
   return (
     <MenuContext.Provider value={setHint}>
       <div
+        ref={menuRef}
         className='menu'
         css={css`
           pointer-events: auto;
-          opacity: ${blur ? 0.3 : 1};
-          transition: opacity 0.15s ease-out;
+          display: flex;
+          flex-direction: column;
+          min-width: 22rem;
+          max-height: calc(100vh - 4rem);
+          background: var(--hf-color-surface);
+          border: 1px solid var(--hf-color-border);
+          border-radius: 1rem;
+          box-shadow: var(--hf-shadow-hard);
+          opacity: ${blur ? 0.35 : 1};
+          transition: opacity var(--hf-transition-medium);
           font-size: 1rem;
+          color: var(--hf-color-text);
+          overflow: hidden;
+          &:focus-visible {
+            outline: 0.2rem solid var(--hf-color-focus);
+            outline-offset: 0.15rem;
+          }
           .menu-head {
-            background: #0f1018;
-            padding: 1rem;
+            background: var(--hf-color-surface-raised);
+            padding: 1rem 1.25rem;
             white-space: nowrap;
             text-overflow: ellipsis;
             overflow: hidden;
             span {
               font-size: 1.3rem;
               font-weight: 600;
+              color: var(--hf-color-heading);
             }
           }
           .menu-items {
-            background-color: rgba(15, 16, 24, 0.8);
+            background-color: var(--hf-color-surface);
             overflow-y: auto;
             max-height: calc(2.5rem * 9.5);
+            flex: 1 1 auto;
           }
         `}
+        role='dialog'
+        aria-modal='true'
+        tabIndex={-1}
       >
         <div className='menu-head'>
           <span>{title}</span>
@@ -57,11 +80,12 @@ function MenuHint({ text }) {
       className='menuhint'
       css={css`
         margin-top: 0.2rem;
-        padding: 0.875rem;
-        font-size: 1rem;
+        padding: 0.875rem 1.25rem;
+        font-size: 0.95rem;
         line-height: 1.4;
-        background-color: rgba(15, 16, 24, 0.8);
-        border-top: 0.1rem solid black;
+        background-color: var(--hf-color-surface-raised);
+        border-top: 0.1rem solid var(--hf-color-border);
+        color: var(--hf-color-text-muted);
       `}
     >
       <span>{text}</span>
@@ -72,14 +96,19 @@ function MenuHint({ text }) {
 export function MenuItemBack({ hint, onClick }) {
   const setHint = useContext(MenuContext)
   return (
-    <label
+    <button
       className='menuback'
       css={css`
         display: flex;
         align-items: center;
         height: 2.5rem;
-        padding: 0 0.825rem;
+        padding: 0 1.25rem;
         font-size: 1rem;
+        background: none;
+        border: none;
+        width: 100%;
+        color: inherit;
+        text-align: left;
         > svg {
           margin-left: -0.25rem;
         }
@@ -88,18 +117,23 @@ export function MenuItemBack({ hint, onClick }) {
         }
         &:hover {
           cursor: pointer;
-          background: rgba(255, 255, 255, 0.05);
+          background: var(--hf-color-surface-hover);
+        }
+        &:focus-visible {
+          outline: none;
+          background: var(--hf-color-surface-hover);
         }
       `}
       onPointerEnter={() => setHint(hint)}
       onPointerLeave={() => setHint(null)}
       onClick={onClick}
+      type='button'
     >
       <ChevronLeftIcon size={'1.5rem'} />
       <div className='menuback-label'>
         <span>Back</span>
       </div>
-    </label>
+    </button>
   )
 }
 
@@ -109,7 +143,7 @@ export function MenuLine() {
       className='menuline'
       css={css`
         height: 0.1rem;
-        background: rgba(255, 255, 255, 0.1);
+        background: var(--hf-color-border);
       `}
     />
   )
@@ -119,10 +153,10 @@ export function MenuSection({ label }) {
   return (
     <div
       css={css`
-        padding: 0.25rem 0.875rem;
+        padding: 0.25rem 1.25rem;
         font-size: 0.75rem;
         font-weight: 500;
-        opacity: 0.3;
+        color: var(--hf-color-text-muted);
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
@@ -136,13 +170,13 @@ export function MenuSection({ label }) {
 export function MenuItemBtn({ label, hint, nav, onClick }) {
   const setHint = useContext(MenuContext)
   return (
-    <div
+    <button
       className='menuitembtn'
       css={css`
         display: flex;
         align-items: center;
         height: 2.5rem;
-        padding: 0 0.875rem;
+        padding: 0 1.25rem;
         .menuitembtn-label {
           flex: 1;
           white-space: nowrap;
@@ -151,16 +185,27 @@ export function MenuItemBtn({ label, hint, nav, onClick }) {
         }
         &:hover {
           cursor: pointer;
-          background: rgba(255, 255, 255, 0.05);
+          background: var(--hf-color-surface-hover);
+        }
+        background: none;
+        border: none;
+        color: inherit;
+        text-align: left;
+        width: 100%;
+        gap: 0.4rem;
+        &:focus-visible {
+          outline: none;
+          background: var(--hf-color-surface-hover);
         }
       `}
       onPointerEnter={() => setHint(hint)}
       onPointerLeave={() => setHint(null)}
       onClick={onClick}
+      type='button'
     >
       <div className='menuitembtn-label'>{label}</div>
       {nav && <ChevronRightIcon size='1.5rem' />}
-    </div>
+    </button>
   )
 }
 
@@ -177,7 +222,7 @@ export function MenuItemText({ label, hint, placeholder, value, onChange }) {
         display: flex;
         align-items: center;
         height: 2.5rem;
-        padding: 0 0.875rem;
+        padding: 0 1.25rem;
         cursor: text;
         .menuitemtext-label {
           width: 9.4rem;
@@ -192,13 +237,12 @@ export function MenuItemText({ label, hint, placeholder, value, onChange }) {
         input {
           text-align: right;
           cursor: inherit;
-          &::selection {
-            background-color: white;
-            color: rgba(0, 0, 0, 0.8);
-          }
         }
         &:hover {
-          background-color: rgba(255, 255, 255, 0.05);
+          background-color: var(--hf-color-surface-hover);
+        }
+        &:focus-within {
+          background-color: var(--hf-color-surface-hover);
         }
       `}
       onPointerEnter={() => setHint(hint)}
@@ -237,8 +281,8 @@ export function MenuItemStatic({ label, hint, value }) {
         display: flex;
         align-items: center;
         height: 2.5rem;
-        padding: 0 0.875rem;
-        opacity: 0.7;
+        padding: 0 1.25rem;
+        color: var(--hf-color-text-muted);
         .menuitemstatic-label {
           width: 9.4rem;
           flex-shrink: 0;
@@ -272,6 +316,7 @@ export function MenuItemTextarea({ label, hint, placeholder, value, onChange }) 
   }, [value])
   useEffect(() => {
     const textarea = textareaRef.current
+    if (!textarea) return
     function update() {
       textarea.style.height = 'auto'
       textarea.style.height = textarea.scrollHeight + 'px'
@@ -281,7 +326,7 @@ export function MenuItemTextarea({ label, hint, placeholder, value, onChange }) 
     return () => {
       textarea.removeEventListener('input', update)
     }
-  }, [])
+  }, [localValue])
   return (
     <label
       className='menuitemtext'
@@ -289,7 +334,7 @@ export function MenuItemTextarea({ label, hint, placeholder, value, onChange }) 
         display: flex;
         align-items: flex-start;
         min-height: 2.5rem;
-        padding: 0 0.875rem;
+        padding: 0 1.25rem;
         cursor: text;
         .menuitemtext-label {
           padding-top: 0.6rem;
@@ -311,13 +356,12 @@ export function MenuItemTextarea({ label, hint, placeholder, value, onChange }) 
           overflow: hidden;
           resize: none;
           cursor: inherit;
-          &::selection {
-            background-color: white;
-            color: rgba(0, 0, 0, 0.8);
-          }
         }
         &:hover {
-          background-color: rgba(255, 255, 255, 0.05);
+          background-color: var(--hf-color-surface-hover);
+        }
+        &:focus-within {
+          background-color: var(--hf-color-surface-hover);
         }
       `}
       onPointerEnter={() => setHint(hint)}
@@ -382,7 +426,7 @@ export function MenuItemNumber({ label, hint, dp = 0, min = -Infinity, max = Inf
         display: flex;
         align-items: center;
         height: 2.5rem;
-        padding: 0 0.875rem;
+        padding: 0 1.25rem;
         cursor: text;
         .menuitemnumber-label {
           width: 9.4rem;
@@ -399,14 +443,13 @@ export function MenuItemNumber({ label, hint, dp = 0, min = -Infinity, max = Inf
           text-align: right;
           overflow: hidden;
           cursor: inherit;
-          &::selection {
-            background-color: white;
-            color: rgba(0, 0, 0, 0.8);
-          }
         }
         &:hover {
           cursor: pointer;
-          background: rgba(255, 255, 255, 0.05);
+          background: var(--hf-color-surface-hover);
+        }
+        &:focus-within {
+          background: var(--hf-color-surface-hover);
         }
       `}
       onPointerEnter={() => setHint(hint)}
@@ -462,6 +505,7 @@ export function MenuItemRange({ label, hint, min = 0, max = 1, step = 0.05, inst
   }, [sliding, value])
   useEffect(() => {
     const track = trackRef.current
+    if (!track) return
     function calculateValueFromPointer(e, trackElement) {
       const rect = trackElement.getBoundingClientRect()
       const position = (e.clientX - rect.left) / rect.width
@@ -503,16 +547,60 @@ export function MenuItemRange({ label, hint, min = 0, max = 1, step = 0.05, inst
       track.removeEventListener('pointermove', onPointerMove)
       track.removeEventListener('pointerup', onPointerUp)
     }
-  }, [])
-  const barWidthPercentage = ((local - min) / (max - min)) * 100 + ''
+  }, [instant, max, min, step])
+  const clampToRange = useMemo(() => {
+    return newValue => {
+      if (!Number.isFinite(newValue)) return min
+      if (max <= min) return min
+      const safeStep = step === 0 ? max - min : step
+      const steps = Math.round((newValue - min) / safeStep)
+      const aligned = min + steps * safeStep
+      return Math.max(min, Math.min(max, aligned))
+    }
+  }, [min, max, step])
+  const commitValue = useMemo(() => {
+    return nextValue => {
+      const aligned = clampToRange(nextValue)
+      setLocal(aligned)
+      onChange(aligned)
+    }
+  }, [clampToRange, onChange])
+  const handleKeyDown = event => {
+    let delta = 0
+    if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+      delta = step
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+      delta = -step
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      commitValue(min)
+      return
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      commitValue(max)
+      return
+    } else if (event.key === 'PageUp') {
+      delta = step * 10
+    } else if (event.key === 'PageDown') {
+      delta = -step * 10
+    } else {
+      return
+    }
+    event.preventDefault()
+    commitValue(local + delta)
+  }
+  const alignedLocal = clampToRange(local)
+  const range = max - min
+  const safeRange = range === 0 ? 1 : range
+  const barWidthPercentage = ((alignedLocal - min) / safeRange) * 100 + ''
   const text = useMemo(() => {
-    const num = local
+    const num = alignedLocal
     const decimalDigits = (num.toString().split('.')[1] || '').length
     if (decimalDigits <= 2) {
       return num.toString()
     }
     return num.toFixed(2)
-  }, [local])
+  }, [alignedLocal])
   return (
     <div
       className='menuitemrange'
@@ -520,7 +608,7 @@ export function MenuItemRange({ label, hint, min = 0, max = 1, step = 0.05, inst
         display: flex;
         align-items: center;
         height: 2.5rem;
-        padding: 0 0.875rem;
+        padding: 0 1.25rem;
         .menuitemrange-label {
           flex: 1;
           white-space: nowrap;
@@ -532,6 +620,7 @@ export function MenuItemRange({ label, hint, min = 0, max = 1, step = 0.05, inst
           font-size: 0.7rem;
           margin-right: 0.5rem;
           opacity: 0;
+          color: var(--hf-color-text-muted);
         }
         .menuitemrange-track {
           width: 7rem;
@@ -540,18 +629,31 @@ export function MenuItemRange({ label, hint, min = 0, max = 1, step = 0.05, inst
           border-radius: 0.1rem;
           display: flex;
           align-items: stretch;
-          background-color: rgba(255, 255, 255, 0.1);
+          background-color: var(--hf-color-border);
           &:hover {
             cursor: pointer;
           }
         }
         .menuitemrange-bar {
-          background-color: white;
+          background-color: var(--hf-color-primary);
           border-radius: 0.1rem;
           width: ${barWidthPercentage}%;
         }
         &:hover {
-          background-color: rgba(255, 255, 255, 0.05);
+          background-color: var(--hf-color-surface-hover);
+          .menuitemrange-text {
+            opacity: 1;
+          }
+        }
+        &:focus-visible {
+          outline: none;
+          background-color: var(--hf-color-surface-hover);
+          .menuitemrange-text {
+            opacity: 1;
+          }
+        }
+        &:focus-within {
+          background-color: var(--hf-color-surface-hover);
           .menuitemrange-text {
             opacity: 1;
           }
@@ -559,6 +661,14 @@ export function MenuItemRange({ label, hint, min = 0, max = 1, step = 0.05, inst
       `}
       onPointerEnter={() => setHint(hint)}
       onPointerLeave={() => setHint(null)}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      role='slider'
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={Number(alignedLocal.toFixed(4))}
+      aria-valuetext={text}
+      aria-orientation='horizontal'
     >
       <div className='menuitemrange-label'>{label}</div>
       <div className='menuitemrange-text'>{text}</div>
@@ -584,6 +694,16 @@ export function MenuItemSwitch({ label, hint, options, value, onChange }) {
     if (nextIdx > options.length - 1) nextIdx = 0
     onChange(options[nextIdx].value)
   }
+  const handleKeyDown = e => {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      prev()
+    }
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      next()
+    }
+  }
   return (
     <div
       className='menuitemswitch'
@@ -591,7 +711,7 @@ export function MenuItemSwitch({ label, hint, options, value, onChange }) {
         display: flex;
         align-items: center;
         height: 2.5rem;
-        padding: 0 0.875rem;
+        padding: 0 1.25rem;
         .menuitemswitch-label {
           flex: 1;
           white-space: nowrap;
@@ -599,24 +719,29 @@ export function MenuItemSwitch({ label, hint, options, value, onChange }) {
           overflow: hidden;
           padding-right: 1rem;
         }
-        .menuitemswitch-btn {
-          width: 2.125rem;
-          height: 2.125rem;
-          display: none;
-          align-items: center;
-          justify-content: center;
-          opacity: 0.2;
-          &:hover {
-            cursor: pointer;
-            opacity: 1;
+          .menuitemswitch-btn {
+            width: 2.125rem;
+            height: 2.125rem;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            opacity: 0.2;
+            background: none;
+            border: none;
+            color: var(--hf-color-text-muted);
+            &:hover {
+              cursor: pointer;
+              opacity: 1;
+              color: var(--hf-color-heading);
+            }
           }
-        }
-        .menuitemswitch-text {
-          line-height: 1;
-        }
-        &:hover {
+          .menuitemswitch-text {
+            line-height: 1;
+          }
+        &:hover,
+        &:focus-within {
           padding: 0 0.275rem 0 0.875rem;
-          background-color: rgba(255, 255, 255, 0.05);
+          background-color: var(--hf-color-surface-hover);
           .menuitemswitch-btn {
             display: flex;
           }
@@ -624,15 +749,19 @@ export function MenuItemSwitch({ label, hint, options, value, onChange }) {
       `}
       onPointerEnter={() => setHint(hint)}
       onPointerLeave={() => setHint(null)}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      role='group'
+      aria-label={label}
     >
       <div className='menuitemswitch-label'>{label}</div>
-      <div className='menuitemswitch-btn left' onClick={prev}>
+      <button className='menuitemswitch-btn left' type='button' onClick={prev} aria-label='Previous option'>
         <ChevronLeftIcon size='1.5rem' />
-      </div>
+      </button>
       <div className='menuitemswitch-text'>{selected?.label || '???'}</div>
-      <div className='menuitemswitch-btn right' onClick={next}>
+      <button className='menuitemswitch-btn right' type='button' onClick={next} aria-label='Next option'>
         <ChevronRightIcon size='1.5rem' />
-      </div>
+      </button>
     </div>
   )
 }
@@ -649,7 +778,7 @@ export function MenuItemCurve({ label, hint, x, xRange, y, yMin, yMax, value, on
           display: flex;
           align-items: center;
           height: 2.5rem;
-          padding: 0 0.875rem;
+          padding: 0 1.25rem;
         }
         .menuitemcurve-label {
           flex: 1;
@@ -665,7 +794,7 @@ export function MenuItemCurve({ label, hint, x, xRange, y, yMin, yMax, value, on
         }
         &:hover {
           cursor: pointer;
-          background-color: rgba(255, 255, 255, 0.05);
+          background-color: var(--hf-color-surface-hover);
         }
       `}
     >
@@ -735,7 +864,7 @@ export function MenuItemFileBtn({ label, hint, accept, value, onChange }) {
         display: flex;
         align-items: center;
         height: 2.5rem;
-        padding: 0 0.875rem;
+        padding: 0 1.25rem;
         overflow: hidden;
         .menuitemfilebtn-label {
           width: 9.4rem;
@@ -747,7 +876,10 @@ export function MenuItemFileBtn({ label, hint, accept, value, onChange }) {
         }
         &:hover {
           cursor: pointer;
-          background: rgba(255, 255, 255, 0.05);
+          background: var(--hf-color-surface-hover);
+        }
+        &:focus-within {
+          background: var(--hf-color-surface-hover);
         }
       `}
       onPointerEnter={() => setHint(hint)}
@@ -875,7 +1007,7 @@ export function MenuItemFile({ world, label, hint, kind: kindName, value, onChan
         display: flex;
         align-items: center;
         height: 2.5rem;
-        padding: 0 0.875rem;
+        padding: 0 1.25rem;
         overflow: hidden;
         input {
           position: absolute;
@@ -894,7 +1026,7 @@ export function MenuItemFile({ world, label, hint, kind: kindName, value, onChan
           padding-right: 1rem;
         }
         .menuitemfile-placeholder {
-          color: rgba(255, 255, 255, 0.3);
+          color: var(--hf-color-text-muted);
         }
         .menuitemfile-name {
           text-align: right;
@@ -906,9 +1038,9 @@ export function MenuItemFile({ world, label, hint, kind: kindName, value, onChan
         .menuitemfile-x {
           line-height: 0;
           margin: 0 -0.2rem 0 0.3rem;
-          color: rgba(255, 255, 255, 0.3);
+          color: var(--hf-color-text-muted);
           &:hover {
-            color: white;
+            color: var(--hf-color-heading);
           }
         }
         .menuitemfile-loading {
@@ -930,7 +1062,10 @@ export function MenuItemFile({ world, label, hint, kind: kindName, value, onChan
         }
         &:hover {
           cursor: pointer;
-          background: rgba(255, 255, 255, 0.05);
+          background: var(--hf-color-surface-hover);
+        }
+        &:focus-within {
+          background: var(--hf-color-surface-hover);
         }
       `}
       onPointerEnter={() => setHint(hint)}
@@ -958,13 +1093,18 @@ export function MenuItemFile({ world, label, hint, kind: kindName, value, onChan
 export function MenuItemToggle({ label, hint, trueLabel = 'Yes', falseLabel = 'No', value, onChange }) {
   const setHint = useContext(MenuContext)
   return (
-    <div
+    <button
       className='menuitemtoggle'
       css={css`
         display: flex;
         align-items: center;
         height: 2.5rem;
-        padding: 0 0.875rem;
+        padding: 0 1.25rem;
+        width: 100%;
+        background: none;
+        border: none;
+        color: inherit;
+        text-align: left;
         .menuitemtoggle-label {
           flex: 1;
           white-space: nowrap;
@@ -973,19 +1113,28 @@ export function MenuItemToggle({ label, hint, trueLabel = 'Yes', falseLabel = 'N
           padding-right: 1rem;
         }
         .menuitemtoggle-text {
-          // ...
+          font-weight: 500;
+          min-width: 4rem;
+          text-align: right;
+          color: ${value ? 'var(--hf-color-primary)' : 'var(--hf-color-text-muted)'};
         }
         &:hover {
           cursor: pointer;
-          background: rgba(255, 255, 255, 0.05);
+          background: var(--hf-color-surface-hover);
+        }
+        &:focus-visible {
+          outline: none;
+          background: var(--hf-color-surface-hover);
         }
       `}
       onPointerEnter={() => setHint(hint)}
       onPointerLeave={() => setHint(null)}
       onClick={() => onChange(!value)}
+      type='button'
+      aria-pressed={Boolean(value)}
     >
       <div className='menuitemtoggle-label'>{label}</div>
       <div className='menuitemtoggle-text'>{value ? trueLabel : falseLabel}</div>
-    </div>
+    </button>
   )
 }

--- a/src/client/components/MenuMain.js
+++ b/src/client/components/MenuMain.js
@@ -10,13 +10,17 @@ import {
   MenuItemText,
   MenuItemTextarea,
   MenuItemToggle,
+  MenuItemStatic,
 } from './Menu'
 import { usePermissions } from './usePermissions'
 import { useFullscreen } from './useFullscreen'
 import { STATS_PALETTE_OPTIONS } from '../../core/constants/statsPalettes.js'
 
-export function MenuMain({ world }) {
-  const [pages, setPages] = useState(() => ['index'])
+export function MenuMain({ world, page: initialPage = 'index' }) {
+  const [pages, setPages] = useState(() => [initialPage || 'index'])
+  useEffect(() => {
+    setPages([initialPage || 'index'])
+  }, [initialPage])
   const pop = () => {
     const next = pages.slice()
     next.pop()
@@ -34,6 +38,7 @@ export function MenuMain({ world }) {
   if (page === 'graphics') Page = MenuMainGraphics
   if (page === 'audio') Page = MenuMainAudio
   if (page === 'world') Page = MenuMainWorld
+  if (page === 'help') Page = MenuMainHelp
   return <Page world={world} pop={pop} push={push} />
 }
 
@@ -52,6 +57,12 @@ function MenuMainIndex({ world, pop, push }) {
       <MenuItemBtn label='UI' hint='Change your interface settings' onClick={() => push('ui')} nav />
       <MenuItemBtn label='Graphics' hint='Change your device graphics settings' onClick={() => push('graphics')} nav />
       <MenuItemBtn label='Audio' hint='Change your audio volume' onClick={() => push('audio')} nav />
+      <MenuItemBtn
+        label='Help & Shortcuts'
+        hint='Browse keyboard shortcuts and accessibility tips'
+        onClick={() => push('help')}
+        nav
+      />
       {isBuilder && <MenuItemBtn label='World' hint='Modify world settings' onClick={() => push('world')} nav />}
       {isBuilder && (
         <MenuItemBtn label='Apps' hint='View all apps in the world' onClick={() => world.ui.toggleApps()} />
@@ -67,6 +78,9 @@ function MenuMainUI({ world, pop, push }) {
   const [actions, setActions] = useState(world.prefs.actions)
   const [stats, setStats] = useState(world.prefs.stats)
   const [statsPalette, setStatsPalette] = useState(world.prefs.statsPalette)
+  const [themeMode, setThemeMode] = useState(world.prefs.themeMode)
+  const [themeHuePrimary, setThemeHuePrimary] = useState(world.prefs.themeHuePrimary)
+  const [themeHueNeutral, setThemeHueNeutral] = useState(world.prefs.themeHueNeutral)
   const { isBuilder } = usePermissions(world)
   useEffect(() => {
     const onChange = changes => {
@@ -74,6 +88,9 @@ function MenuMainUI({ world, pop, push }) {
       if (changes.actions) setActions(changes.actions.value)
       if (changes.stats) setStats(changes.stats.value)
       if (changes.statsPalette) setStatsPalette(changes.statsPalette.value)
+      if (changes.themeMode) setThemeMode(changes.themeMode.value)
+      if (changes.themeHuePrimary) setThemeHuePrimary(changes.themeHuePrimary.value)
+      if (changes.themeHueNeutral) setThemeHueNeutral(changes.themeHueNeutral.value)
     }
     world.prefs.on('change', onChange)
     return () => {
@@ -98,6 +115,38 @@ function MenuMainUI({ world, pop, push }) {
         value={ui}
         onChange={ui => world.prefs.setUI(ui)}
       />
+      <MenuSection label='Appearance' />
+      <MenuItemSwitch
+        label='Theme Mode'
+        hint='Switch between dark, light, or system-controlled theming'
+        options={[
+          { label: 'System', value: 'system' },
+          { label: 'Dark', value: 'dark' },
+          { label: 'Light', value: 'light' },
+        ]}
+        value={themeMode}
+        onChange={mode => world.prefs.setThemeMode(mode)}
+      />
+      <MenuItemRange
+        label='Accent Hue'
+        hint='Adjust the hue used for highlights and focus states'
+        min={0}
+        max={360}
+        step={1}
+        instant
+        value={themeHuePrimary}
+        onChange={value => world.prefs.setThemeHuePrimary(value)}
+      />
+      <MenuItemRange
+        label='Surface Hue'
+        hint='Adjust the base hue used for panels and surfaces'
+        min={0}
+        max={360}
+        step={1}
+        instant
+        value={themeHueNeutral}
+        onChange={value => world.prefs.setThemeHueNeutral(value)}
+      />
       {isBuilder && (
         <MenuItemToggle
           label='Build Prompts'
@@ -118,6 +167,33 @@ function MenuMainUI({ world, pop, push }) {
         options={STATS_PALETTE_OPTIONS}
         value={statsPalette}
         onChange={palette => world.prefs.setStatsPalette(palette)}
+      />
+    </Menu>
+  )
+}
+
+function MenuMainHelp({ pop }) {
+  const shortcuts = [
+    { label: 'Open menu', value: 'Esc' },
+    { label: 'Toggle menu', value: 'Ctrl/Cmd + Shift + P' },
+    { label: 'Help overlay', value: 'Shift + ?' },
+    { label: 'Apps pane', value: 'Ctrl/Cmd + Shift + A' },
+  ]
+  return (
+    <Menu title='Help & Shortcuts'>
+      <MenuItemBack hint='Go back to the main menu' onClick={pop} />
+      <MenuSection label='Keyboard shortcuts' />
+      {shortcuts.map(item => (
+        <MenuItemStatic key={item.label} label={item.label} value={item.value} />
+      ))}
+      <MenuSection label='Accessibility' />
+      <MenuItemStatic
+        label='Focus management'
+        value='Overlays keep focus until closed so keyboard navigation stays predictable.'
+      />
+      <MenuItemStatic
+        label='Tab navigation'
+        value='Use Tab and Shift+Tab to move between controls when panes are open.'
       />
     </Menu>
   )

--- a/src/client/components/theme.js
+++ b/src/client/components/theme.js
@@ -1,0 +1,50 @@
+export const DEFAULT_PRIMARY_HUE = 265
+export const DEFAULT_NEUTRAL_HUE = 220
+export const THEME_MODES = ['dark', 'light', 'system']
+
+export function normalizeThemePrefs(prefs = {}) {
+  const themeMode = THEME_MODES.includes(prefs.themeMode) ? prefs.themeMode : 'dark'
+  const themeHuePrimary = isFinite(prefs.themeHuePrimary) ? clampHue(prefs.themeHuePrimary) : DEFAULT_PRIMARY_HUE
+  const themeHueNeutral = isFinite(prefs.themeHueNeutral) ? clampHue(prefs.themeHueNeutral) : DEFAULT_NEUTRAL_HUE
+  return { themeMode, themeHuePrimary, themeHueNeutral }
+}
+
+export function applyThemeFromPrefs(prefs) {
+  const { themeMode, themeHuePrimary, themeHueNeutral } = normalizeThemePrefs(prefs)
+  const resolvedMode = resolveThemeMode(themeMode)
+  const root = document.documentElement
+  root.dataset.theme = resolvedMode
+  root.style.setProperty('--hf-primary-hue', String(themeHuePrimary))
+  root.style.setProperty('--hf-neutral-hue', String(themeHueNeutral))
+  return { themeMode: resolvedMode, themeHuePrimary, themeHueNeutral }
+}
+
+export function watchSystemTheme(onChange) {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {}
+  }
+  const media = window.matchMedia('(prefers-color-scheme: dark)')
+  if (!media.addEventListener) {
+    media.addListener(onChange)
+    return () => media.removeListener(onChange)
+  }
+  media.addEventListener('change', onChange)
+  return () => media.removeEventListener('change', onChange)
+}
+
+function resolveThemeMode(mode) {
+  if (mode !== 'system') {
+    return mode
+  }
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'dark'
+  }
+  const media = window.matchMedia('(prefers-color-scheme: dark)')
+  return media.matches ? 'dark' : 'light'
+}
+
+function clampHue(value) {
+  if (!isFinite(value)) return DEFAULT_PRIMARY_HUE
+  const mod = value % 360
+  return mod < 0 ? mod + 360 : mod
+}

--- a/src/client/components/useFocusTrap.js
+++ b/src/client/components/useFocusTrap.js
@@ -1,0 +1,68 @@
+import { useEffect } from 'react'
+
+const FOCUSABLE_SELECTOR =
+  'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type=hidden]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+function getFocusableElements(root) {
+  if (!root) return []
+  const elements = Array.from(root.querySelectorAll(FOCUSABLE_SELECTOR))
+  return elements.filter(element => element.offsetParent !== null || element === document.activeElement)
+}
+
+export function useFocusTrap(ref, { active = true, initialFocusRef } = {}) {
+  useEffect(() => {
+    if (!active) return
+    const node = ref.current
+    if (!node) return
+
+    const previousActive = document.activeElement
+    const focusTarget = initialFocusRef?.current || node.querySelector('[data-initial-focus]') || node
+
+    const focus = () => {
+      if (focusTarget && typeof focusTarget.focus === 'function') {
+        focusTarget.focus()
+        return
+      }
+      if (typeof node.focus === 'function') {
+        node.focus()
+      }
+    }
+
+    const raf = requestAnimationFrame(focus)
+
+    const handleKeyDown = event => {
+      if (event.key !== 'Tab') return
+      const focusable = getFocusableElements(node)
+      if (focusable.length === 0) {
+        event.preventDefault()
+        focus()
+        return
+      }
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const activeElement = document.activeElement
+
+      if (event.shiftKey) {
+        if (activeElement === first || !node.contains(activeElement)) {
+          event.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (activeElement === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      document.removeEventListener('keydown', handleKeyDown)
+      if (previousActive && typeof previousActive.focus === 'function') {
+        previousActive.focus()
+      }
+    }
+  }, [active, ref, initialFocusRef])
+}

--- a/src/client/public/index.css
+++ b/src/client/public/index.css
@@ -1,14 +1,15 @@
 /**
- * CSS Reset
+ * Global reset & base styles
  */
 html {
   box-sizing: border-box;
   font-size: 16px;
 }
 *,
-*:before,
-*:after {
+*::before,
+*::after {
   box-sizing: inherit;
+  min-width: 0;
 }
 body,
 h1,
@@ -32,49 +33,62 @@ img {
   max-width: 100%;
   height: auto;
 }
-
-/** 
- * Fix common issue with flex ellipsis 
- */
-* {
-  min-width: 0;
-}
-
-/**
- * Fix alignment of svgs
- */
 svg {
   display: inline-block;
 }
 
-/**
- * Text selection color
- */
-::selection {
-  color: white;
-  background: var(--primary-color);
+:root {
+  overscroll-behavior: none;
+  --hf-primary-hue: 265;
+  --hf-neutral-hue: 220;
+  --hf-color-bg: hsl(var(--hf-neutral-hue) 28% 6%);
+  --hf-color-surface: hsl(var(--hf-neutral-hue) 26% 10%);
+  --hf-color-surface-raised: hsl(var(--hf-neutral-hue) 24% 14%);
+  --hf-color-border: hsl(var(--hf-neutral-hue) 38% 26% / 0.32);
+  --hf-color-border-strong: hsl(var(--hf-neutral-hue) 48% 46% / 0.45);
+  --hf-color-text: hsl(var(--hf-neutral-hue) 32% 93%);
+  --hf-color-heading: hsl(var(--hf-neutral-hue) 36% 98%);
+  --hf-color-text-muted: hsl(var(--hf-neutral-hue) 22% 70%);
+  --hf-color-primary: hsl(var(--hf-primary-hue) 88% 68%);
+  --hf-color-primary-soft: hsl(var(--hf-primary-hue) 82% 60% / 0.18);
+  --hf-color-focus: hsl(var(--hf-primary-hue) 92% 72%);
+  --hf-color-surface-hover: rgba(255, 255, 255, 0.06);
+  --hf-shadow-soft: 0 1.1rem 3.2rem rgba(2, 6, 23, 0.42);
+  --hf-shadow-hard: 0 0.75rem 2.2rem rgba(2, 6, 23, 0.6);
+  --hf-transition-medium: 180ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-/**
- * General
- */
-p {
-  line-height: 1.9;
+:root[data-theme='light'] {
+  --hf-color-bg: hsl(var(--hf-neutral-hue) 36% 97%);
+  --hf-color-surface: hsl(var(--hf-neutral-hue) 32% 92%);
+  --hf-color-surface-raised: hsl(var(--hf-neutral-hue) 28% 86%);
+  --hf-color-border: hsl(var(--hf-neutral-hue) 24% 62% / 0.26);
+  --hf-color-border-strong: hsl(var(--hf-neutral-hue) 32% 52% / 0.32);
+  --hf-color-text: hsl(var(--hf-neutral-hue) 30% 13%);
+  --hf-color-heading: hsl(var(--hf-neutral-hue) 34% 10%);
+  --hf-color-text-muted: hsl(var(--hf-neutral-hue) 18% 38%);
+  --hf-color-surface-hover: rgba(15, 23, 42, 0.08);
+  --hf-shadow-soft: 0 1.25rem 2.5rem rgba(15, 23, 42, 0.18);
+  --hf-shadow-hard: 0 0.75rem 1.75rem rgba(15, 23, 42, 0.24);
 }
-pre {
-  margin: 0;
+
+::selection {
+  color: hsl(var(--hf-neutral-hue) 100% 98%);
+  background: var(--hf-color-primary);
 }
-html,
-body {
+
+body,
+html {
   -webkit-font-smoothing: antialiased;
   font-family: 'Rubik', sans-serif;
   font-optical-sizing: auto;
   font-size: 16px;
   font-weight: 400;
   font-style: normal;
-  background-color: black;
-  color: white;
+  background-color: var(--hf-color-bg);
+  color: var(--hf-color-text);
 }
+
 input,
 textarea {
   border: 0;
@@ -88,18 +102,20 @@ textarea {
   font-size: inherit;
   color: inherit;
 }
-input::placeholder,
-textarea::placeholder {
-  /* color: rgba(255, 255, 255, 0.3); */
-}
+
 a {
   text-decoration: none;
   color: inherit;
 }
 
-/**
- * Hyperfy
- */
+.noscrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.noscrollbar::-webkit-scrollbar {
+  display: none;
+}
 
 /* font (latin) */
 @font-face {
@@ -110,81 +126,4 @@ a {
   src: url(/rubik.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
     U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-/* disable scroll bounce */
-
-:root {
-  overscroll-behavior: none;
-}
-
-/* fix common issue with flex ellipsis */
-
-* {
-  min-width: 0;
-}
-
-/* fix alignment of svgs */
-
-svg {
-  display: inline-block;
-}
-
-/* text selection */
-
-::selection {
-  color: white;
-  background: black;
-}
-
-/* hide scrollbar */
-
-.noscrollbar {
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-.noscrollbar::-webkit-scrollbar {
-  display: none;
-}
-
-/* general */
-
-p {
-  line-height: 1.9;
-}
-
-pre {
-  margin: 0;
-}
-
-html,
-body {
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Rubik', sans-serif;
-  font-optical-sizing: auto;
-  font-size: 16px;
-  font-weight: 400;
-  font-style: normal;
-
-  background-color: black;
-  color: white;
-}
-
-input,
-textarea {
-  border: 0;
-  background: none;
-  outline: 0;
-  padding: 0;
-  margin: 0;
-  display: block;
-  width: 100%;
-  font-family: inherit;
-  font-size: inherit;
-  color: inherit;
-}
-
-a {
-  text-decoration: none;
-  color: inherit;
 }

--- a/src/core/systems/ClientControls.js
+++ b/src/core/systems/ClientControls.js
@@ -435,8 +435,11 @@ export class ClientControls extends System {
     }
     const code = e.code
     if (code === 'Tab') {
-      // prevent default focus switching behavior
-      e.preventDefault()
+      const allowTab = this.world.ui?.shouldAllowTabNavigation?.()
+      if (!allowTab) {
+        // prevent default focus switching behavior when UI is controlling focus
+        e.preventDefault()
+      }
     }
     const prop = codeToProp[code]
     const text = e.key

--- a/src/core/systems/ClientPrefs.js
+++ b/src/core/systems/ClientPrefs.js
@@ -5,6 +5,11 @@ import { storage } from '../storage'
 import { isTouch } from '../../client/utils'
 import { isStatsPalette, STATS_PALETTE_DEFAULT } from '../constants/statsPalettes.js'
 
+const THEME_MODES = new Set(['dark', 'light', 'system'])
+const THEME_DEFAULT_MODE = 'dark'
+const THEME_DEFAULT_PRIMARY_HUE = 265
+const THEME_DEFAULT_NEUTRAL_HUE = 220
+
 /**
  * Client Prefs System
  *
@@ -36,11 +41,24 @@ export class ClientPrefs extends System {
       data.v = 5
       data.statsPalette = null
     }
+    if (data.v < 6) {
+      data.v = 6
+      data.themeMode = null
+      data.themeHuePrimary = null
+      data.themeHueNeutral = null
+    }
 
     this.ui = isNumber(data.ui) ? data.ui : isTouch ? 0.9 : 1
     this.actions = isBoolean(data.actions) ? data.actions : true
     this.stats = isBoolean(data.stats) ? data.stats : false
     this.statsPalette = isStatsPalette(data.statsPalette) ? data.statsPalette : STATS_PALETTE_DEFAULT
+    this.themeMode = THEME_MODES.has(data.themeMode) ? data.themeMode : THEME_DEFAULT_MODE
+    this.themeHuePrimary = isNumber(data.themeHuePrimary)
+      ? normalizeHue(data.themeHuePrimary, THEME_DEFAULT_PRIMARY_HUE)
+      : THEME_DEFAULT_PRIMARY_HUE
+    this.themeHueNeutral = isNumber(data.themeHueNeutral)
+      ? normalizeHue(data.themeHueNeutral, THEME_DEFAULT_NEUTRAL_HUE)
+      : THEME_DEFAULT_NEUTRAL_HUE
     this.dpr = isNumber(data.dpr) ? data.dpr : 1
     this.shadows = data.shadows ? data.shadows : isTouch ? 'low' : 'med' // none, low=1, med=2048cascade, high=4096cascade
     this.postprocessing = isBoolean(data.postprocessing) ? data.postprocessing : true
@@ -72,12 +90,16 @@ export class ClientPrefs extends System {
 
   async persist() {
     // a small delay to ensure prefs that crash dont persist (eg old iOS with UHD shadows etc)
+    const start = typeof performance !== 'undefined' ? performance.now() : Date.now()
     await new Promise(resolve => setTimeout(resolve, 2000))
-    storage.set('prefs', {
+    const data = {
       ui: this.ui,
       actions: this.actions,
       stats: this.stats,
       statsPalette: this.statsPalette,
+      themeMode: this.themeMode,
+      themeHuePrimary: this.themeHuePrimary,
+      themeHueNeutral: this.themeHueNeutral,
       dpr: this.dpr,
       shadows: this.shadows,
       postprocessing: this.postprocessing,
@@ -87,6 +109,18 @@ export class ClientPrefs extends System {
       sfx: this.sfx,
       voice: this.voice,
       v: this.v,
+    }
+    storage.set('prefs', data)
+    const end = typeof performance !== 'undefined' ? performance.now() : Date.now()
+    this.world.emit('telemetry', {
+      source: 'prefs',
+      event: 'persisted',
+      duration: end - start,
+      snapshot: {
+        themeMode: this.themeMode,
+        themeHuePrimary: this.themeHuePrimary,
+        themeHueNeutral: this.themeHueNeutral,
+      },
     })
   }
 
@@ -141,7 +175,28 @@ export class ClientPrefs extends System {
     this.modify('voice', value)
   }
 
+  setThemeMode(value) {
+    if (!THEME_MODES.has(value)) {
+      value = THEME_DEFAULT_MODE
+    }
+    this.modify('themeMode', value)
+  }
+
+  setThemeHuePrimary(value) {
+    this.modify('themeHuePrimary', normalizeHue(value, THEME_DEFAULT_PRIMARY_HUE))
+  }
+
+  setThemeHueNeutral(value) {
+    this.modify('themeHueNeutral', normalizeHue(value, THEME_DEFAULT_NEUTRAL_HUE))
+  }
+
   destroy() {
     // ...
   }
+}
+
+function normalizeHue(value, fallback) {
+  if (!isNumber(value)) return fallback
+  const hue = value % 360
+  return hue < 0 ? hue + 360 : hue
 }

--- a/src/core/systems/ClientUI.js
+++ b/src/core/systems/ClientUI.js
@@ -1,7 +1,6 @@
 import { isBoolean } from 'lodash-es'
 import { ControlPriorities } from '../extras/ControlPriorities'
 import { System } from './System'
-import { thickness } from 'three/src/nodes/TSL.js'
 
 const appPanes = ['app', 'script', 'nodes', 'meta']
 
@@ -13,6 +12,8 @@ export class ClientUI extends System {
       active: false,
       app: null,
       pane: null,
+      menu: null,
+      apps: false,
       reticleSuppressors: 0,
     }
     this.lastAppPane = 'app'
@@ -23,25 +24,74 @@ export class ClientUI extends System {
     this.control = this.world.controls.bind({ priority: ControlPriorities.CORE_UI })
   }
 
+  getLocalizedString(key, fallback) {
+    const sources = [this.world.language, this.world.locale, this.world.i18n]
+    const tryFromSource = source => {
+      if (!source) return null
+      const callMaybe = fn => {
+        if (typeof fn !== 'function') return null
+        try {
+          const result = fn.call(source, key, fallback)
+          return typeof result === 'string' ? result : null
+        } catch (err) {
+          return null
+        }
+      }
+      const fromFunction =
+        callMaybe(source.t) || callMaybe(source.translate) || callMaybe(source.get)
+      if (fromFunction) return fromFunction
+      if (typeof source[key] === 'string') return source[key]
+      if (source.strings && typeof source.strings[key] === 'string') {
+        return source.strings[key]
+      }
+      return null
+    }
+    for (const source of sources) {
+      const localized = tryFromSource(source)
+      if (localized) return localized
+    }
+    return fallback
+  }
+
   update() {
+    const ctrlDown =
+      this.control.controlLeft.down || this.control.controlRight.down || this.control.metaLeft.down
+    const shiftDown = this.control.shiftLeft.down || this.control.shiftRight.down
+    const altDown = this.control.altLeft.down || this.control.altRight.down
+
     if (this.control.escape.pressed) {
-      if (this.state.pane) {
+      if (this.state.menu) {
+        this.setMenu(null)
+      } else if (this.state.apps) {
+        this.toggleApps(false)
+      } else if (this.state.pane) {
         this.state.pane = null
         this.broadcast()
       } else if (this.state.app) {
         this.state.app = null
         this.broadcast()
+      } else {
+        this.setMenu({ type: 'main' })
       }
     }
-    if (
-      this.control.keyZ.pressed &&
-      !this.control.metaLeft.down &&
-      !this.control.controlLeft.down &&
-      !this.control.shiftLeft.down
-    ) {
+
+    if (this.control.keyP.pressed && ctrlDown && shiftDown) {
+      this.toggleMenu('main')
+    }
+
+    if (this.control.keyA.pressed && ctrlDown && shiftDown) {
+      this.toggleApps()
+    }
+
+    if (this.control.slash.pressed && shiftDown && !ctrlDown && !altDown) {
+      this.setMenu({ type: 'main', page: 'help' })
+    }
+
+    if (!ctrlDown && !shiftDown && this.control.keyZ.pressed) {
       this.state.visible = !this.state.visible
       this.broadcast()
     }
+
     if (this.control.pointer.locked && this.state.active) {
       this.state.active = false
       this.broadcast()
@@ -67,6 +117,56 @@ export class ClientUI extends System {
     this.broadcast()
   }
 
+  toggleMenu(type = 'main', options = {}) {
+    if (this.state.menu?.type === type && !options.force) {
+      this.setMenu(null)
+      return
+    }
+    this.setMenu({ type, ...options })
+  }
+
+  setMenu(menu) {
+    if (!menu) {
+      if (!this.state.menu) return
+      this.state.menu = null
+      this.broadcast()
+      return
+    }
+    const next = { ...menu }
+    if (!next.type) {
+      next.type = 'main'
+    }
+    this.state.menu = next
+    this.state.visible = true
+    if (next.type !== 'app') {
+      this.state.app = null
+    }
+    this.broadcast()
+  }
+
+  toggleApps(value) {
+    const next = isBoolean(value) ? value : !this.state.apps
+    if (next && !this.state.apps) {
+      const player = this.world.entities.player
+      const canOpen = player?.isBuilder?.()
+      if (!canOpen) {
+        const message = this.getLocalizedString(
+          'ui.apps.buildersOnly',
+          'Apps pane is available to builders only.'
+        )
+        this.world.emit('toast', message)
+        return
+      }
+    }
+    if (this.state.apps === next) return
+    this.state.apps = next
+    if (next) {
+      this.state.visible = true
+      this.state.menu = null
+    }
+    this.broadcast()
+  }
+
   toggleVisible(value) {
     value = isBoolean(value) ? value : !this.state.visible
     if (this.state.visible === value) return
@@ -78,6 +178,10 @@ export class ClientUI extends System {
     this.state.app = app
     this.state.pane = app ? this.lastAppPane : null
     this.broadcast()
+  }
+
+  shouldAllowTabNavigation() {
+    return !!(this.state.menu || this.state.apps)
   }
 
   suppressReticle() {


### PR DESCRIPTION
## Summary
- introduce theme preferences, focus traps, and accessible menu controls for the rebuilt client menus
- modernize the apps pane with animations, keyboard support, and builder-only safeguards
- extend client prefs, controls, and telemetry docs to cover new shortcuts, theme persistence, and responsiveness tracking

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f9088f805c832da89480e047012f43