### PR TITLE
Add server observability metrics and diagnostics tools

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,4 @@ These docs are for 3D artists and developers looking to build assets and/or full
 - [Models](/docs/supported-files/models.md)
 - [App Scripting API](/docs/scripting/README.md)
 - [MMORPG Systems Integration Guide](/docs/mmorpg-systems.md)
+- [Observability & Diagnostics](/docs/observability.md)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,68 @@
+# Observability & Diagnostics
+
+Hyperfy now exposes richer runtime telemetry that makes it easier to diagnose
+server pressure before it becomes a player-facing outage. This page summarises
+the `/metrics` endpoint additions and how to work with the accompanying
+command-line tooling.
+
+## `/metrics` payload
+
+Every configured zone reports the following structure:
+
+| Field | Description |
+| ----- | ----------- |
+| `ticks.expectedRate` | The configured server tick rate for the zone. |
+| `ticks.observedRate` | Rolling average of ticks-per-second measured over the last 10 seconds. |
+| `ticks.averageDurationMs` | Mean wall-clock duration of each simulation tick in the sample window. |
+| `ticks.maxDurationMs` | Maximum tick duration observed during the window. |
+| `ticks.averageDeltaMs` | Average simulation delta (in milliseconds) derived from the physics step cadence. |
+| `ticks.sampleCount` | Number of ticks contributing to the current statistics. |
+| `ticks.windowMs` | Size of the sampling window (currently 10 seconds). |
+| `eventLoop.*` | Event-loop delay histogram in milliseconds (`minMs`, `maxMs`, `meanMs`, `p99Ms`). |
+| `issues` | Array of diagnostic flags raised when thresholds are exceeded. |
+
+`issues` currently includes:
+
+- `tick-rate-degraded` – observed tick rate is more than 10% below the target.
+- `tick-duration-spike` – a tick lasted more than 2× the expected frame budget.
+- `event-loop-lag` – the 99th percentile event-loop delay exceeds 50 ms.
+- `cpu-saturation` – instantaneous CPU usage is above 90 % of available cores.
+- `memory-pressure` – RSS exceeds 90 % of system memory.
+
+These signals do not halt the process, but they highlight bottlenecks that are
+likely to cause hitching, desync, or crashes under load.
+
+## CLI: `npm run diagnostics`
+
+A new diagnostics runner polls `/metrics` and renders a human-readable summary.
+It is useful both for local development (sanity checking your world while you
+stress-test it) and for lightweight production monitoring.
+
+```bash
+# Show a single snapshot from the local server
+npm run diagnostics
+
+# Poll a remote deployment every five seconds
+npm run diagnostics -- --url https://example.com --watch --interval 5
+
+# Emit raw JSON (useful for piping to `jq`)
+npm run diagnostics -- --json
+```
+
+The script respects the `HYPERFY_DIAGNOSTICS_URL` environment variable if you
+prefer not to pass `--url` on every invocation.
+
+## Operational tips
+
+- A sustained `tick-rate-degraded` issue suggests the simulation loop cannot
+  keep up with the configured cadence. Consider reducing expensive scripts,
+  lowering the configured tick rate, or scaling out to additional zones.
+- `event-loop-lag` often indicates blocking work on the main thread (for
+  example, synchronous filesystem operations). Profiling with Node's inspector
+  or moving heavy tasks to workers can help.
+- `cpu-saturation` and `memory-pressure` are early warnings that the host is at
+  capacity. Schedule failover or horizontal scaling before they become hard
+  outages.
+- Export `/metrics` into your existing observability stack (Prometheus, DataDog,
+  etc.) for alerting. The JSON schema is stable and designed to be easy to map
+  into custom dashboards.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "client:build": "node scripts/build-client.mjs",
     "node-client:dev": "node scripts/build-node-client.mjs --dev",
     "node-client:build": "node scripts/build-node-client.mjs",
+    "diagnostics": "node scripts/server-diagnostics.mjs",
     "lint": "eslint . --ext .js,.jsx",
     "lint:fix": "eslint . --ext .js,.jsx --fix",
     "format": "prettier --write .",

--- a/scripts/server-diagnostics.mjs
+++ b/scripts/server-diagnostics.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import process from 'node:process'
+import { setTimeout as delay } from 'node:timers/promises'
+
+const DEFAULT_URL = process.env.HYPERFY_DIAGNOSTICS_URL ?? 'http://localhost:3000'
+
+function printUsage() {
+  console.log(`Usage: npm run diagnostics -- [options]\n\n` +
+    `Options:\n` +
+    `  --url <url>        Base URL for the Hyperfy server (default: ${DEFAULT_URL})\n` +
+    `  --watch            Continuously poll /metrics and stream summaries\n` +
+    `  --interval <sec>   Interval in seconds when using --watch (default: 10)\n` +
+    `  --json             Output raw JSON response\n` +
+    `  -h, --help         Show this help message\n`)
+}
+
+function parseArgs(argv) {
+  const options = {
+    url: DEFAULT_URL,
+    watch: false,
+    intervalSec: 10,
+    json: false,
+  }
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]
+    if (!arg) continue
+
+    if (arg === '--help' || arg === '-h') {
+      printUsage()
+      process.exit(0)
+    } else if (arg === '--url') {
+      const value = argv[++index]
+      if (!value) {
+        throw new Error('--url requires a value')
+      }
+      options.url = value
+    } else if (arg.startsWith('--url=')) {
+      options.url = arg.slice('--url='.length)
+    } else if (arg === '--watch') {
+      options.watch = true
+    } else if (arg === '--interval') {
+      const value = argv[++index]
+      if (!value) {
+        throw new Error('--interval requires a value')
+      }
+      options.intervalSec = Number.parseFloat(value)
+    } else if (arg.startsWith('--interval=')) {
+      options.intervalSec = Number.parseFloat(arg.slice('--interval='.length))
+    } else if (arg === '--json') {
+      options.json = true
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!Number.isFinite(options.intervalSec) || options.intervalSec <= 0) {
+    options.intervalSec = 10
+  }
+
+  return options
+}
+
+async function fetchMetrics(baseUrl) {
+  const url = new URL('/metrics', baseUrl)
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Request failed with status ${response.status}: ${body || response.statusText}`)
+  }
+
+  return response.json()
+}
+
+function formatNumber(value, { digits = 1, fallback = '0.0' } = {}) {
+  if (!Number.isFinite(value)) {
+    return fallback
+  }
+  return Number.parseFloat(value).toFixed(digits)
+}
+
+function summariseZone(zone) {
+  const players = zone.players ?? 0
+  const cpuPercent = zone.maxCPU ? (zone.cpu / zone.maxCPU) * 100 : 0
+  const memoryPercent = zone.maxMemory ? (zone.memory / zone.maxMemory) * 100 : 0
+  const expectedRate = zone.ticks?.expectedRate ?? 0
+  const observedRate = zone.ticks?.observedRate ?? 0
+  const averageTick = zone.ticks?.averageDurationMs ?? 0
+  const maxTick = zone.ticks?.maxDurationMs ?? 0
+  const eventLoopP99 = zone.eventLoop?.p99Ms
+
+  console.log(
+    `• ${zone.label} (${zone.id}) — players: ${players}, tick: ${formatNumber(observedRate, { digits: 2 })}/${formatNumber(
+      expectedRate,
+      { digits: 2 }
+    )} tps`
+  )
+  console.log(
+    `    tick budget: avg ${formatNumber(averageTick, { digits: 2 })} ms, max ${formatNumber(maxTick, { digits: 2 })} ms`
+  )
+  console.log(
+    `    CPU ${formatNumber(cpuPercent, { digits: 1 })}% of ${formatNumber(zone.maxCPU, { digits: 0, fallback: '0' })}% | ` +
+      `Memory ${formatNumber(memoryPercent, { digits: 1 })}% of ${formatNumber(zone.maxMemory, { digits: 0, fallback: '0' })} MB`
+  )
+  if (Number.isFinite(eventLoopP99)) {
+    console.log(`    Event loop p99: ${formatNumber(eventLoopP99, { digits: 2 })} ms`)
+  } else {
+    console.log('    Event loop p99: n/a')
+  }
+
+  if (Array.isArray(zone.issues) && zone.issues.length > 0) {
+    console.log(`    Issues: ⚠️  ${zone.issues.join(', ')}`)
+  } else {
+    console.log('    Issues: ✅  none detected')
+  }
+}
+
+async function run() {
+  let options
+  try {
+    options = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(error.message)
+    printUsage()
+    process.exit(1)
+  }
+
+  let iteration = 0
+  do {
+    try {
+      const snapshot = await fetchMetrics(options.url)
+      if (options.json) {
+        console.log(JSON.stringify(snapshot, null, 2))
+      } else {
+        if (iteration > 0) {
+          console.log('')
+        }
+        console.log(`Metrics snapshot — ${snapshot.timestamp ?? new Date().toISOString()}`)
+        for (const zone of snapshot.zones ?? []) {
+          summariseZone(zone)
+        }
+        if (!snapshot.zones || snapshot.zones.length === 0) {
+          console.log('No zones reported by /metrics.')
+        }
+      }
+    } catch (error) {
+      console.error(`Failed to fetch metrics: ${error.message}`)
+      if (!options.watch) {
+        process.exitCode = 1
+        return
+      }
+    }
+
+    iteration += 1
+    if (!options.watch) {
+      break
+    }
+
+    await delay(options.intervalSec * 1000)
+  } while (true)
+}
+
+run().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/core/World.js
+++ b/src/core/World.js
@@ -1,6 +1,13 @@
 import * as THREE from './extras/three'
 import EventEmitter from 'eventemitter3'
 
+const getHighResTime = (() => {
+  if (typeof globalThis !== 'undefined' && globalThis.performance && typeof globalThis.performance.now === 'function') {
+    return () => globalThis.performance.now()
+  }
+  return () => Date.now()
+})()
+
 import { Settings } from './systems/Settings'
 import { Collections } from './systems/Collections'
 import { Apps } from './systems/Apps'
@@ -82,6 +89,7 @@ export class World extends EventEmitter {
   }
 
   tick = time => {
+    const tickStart = getHighResTime()
     // begin any stats/performance monitors
     this.preTick()
     // update time, delta, frame and accumulator
@@ -121,6 +129,14 @@ export class World extends EventEmitter {
     this.commit()
     // end any stats/performance monitors
     this.postTick()
+
+    const duration = getHighResTime() - tickStart
+    this.emit('tick', {
+      frame: this.frame,
+      time: this.time,
+      delta,
+      duration,
+    })
   }
 
   preTick() {

--- a/src/core/systems/ServerMonitor.js
+++ b/src/core/systems/ServerMonitor.js
@@ -1,22 +1,149 @@
-import { System } from './System'
 import os from 'os'
+import { monitorEventLoopDelay, performance as perfHooksPerformance } from 'node:perf_hooks'
+
+import { System } from './System'
+
+const SAMPLE_WINDOW_MS = 10_000
+
+const getHighResTime = () => {
+  if (perfHooksPerformance && typeof perfHooksPerformance.now === 'function') {
+    return perfHooksPerformance.now()
+  }
+  if (typeof globalThis !== 'undefined' && globalThis.performance && typeof globalThis.performance.now === 'function') {
+    return globalThis.performance.now()
+  }
+  return Date.now()
+}
+
+function toMilliseconds(value) {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+  return value / 1e6
+}
 
 export class ServerMonitor extends System {
   constructor(world) {
     super(world)
+    this.sampleWindowMs = SAMPLE_WINDOW_MS
+    this.samples = []
+    this.totalDuration = 0
+    this.totalDelta = 0
+    this.maxDuration = 0
+    this.eventLoopMonitor = typeof monitorEventLoopDelay === 'function' ? monitorEventLoopDelay({ resolution: 20 }) : null
+    this.eventLoopMonitorEnabled = false
+    this.handleTick = this.handleTick.bind(this)
+  }
+
+  start() {
+    if (this.eventLoopMonitor && !this.eventLoopMonitorEnabled) {
+      this.eventLoopMonitor.enable()
+      this.eventLoopMonitorEnabled = true
+    }
+
+    if (typeof this.world?.on === 'function') {
+      this.world.on('tick', this.handleTick)
+    }
+  }
+
+  destroy() {
+    if (this.eventLoopMonitor && this.eventLoopMonitorEnabled) {
+      this.eventLoopMonitor.disable()
+      this.eventLoopMonitorEnabled = false
+    }
+
+    if (typeof this.world?.off === 'function') {
+      this.world.off('tick', this.handleTick)
+    } else if (typeof this.world?.removeListener === 'function') {
+      this.world.removeListener('tick', this.handleTick)
+    }
+
+    this.samples = []
+    this.totalDuration = 0
+    this.totalDelta = 0
+    this.maxDuration = 0
+  }
+
+  handleTick(event) {
+    const timestamp = getHighResTime()
+    const duration = Number.isFinite(event?.duration) ? event.duration : 0
+    const delta = Number.isFinite(event?.delta) ? event.delta : 0
+
+    this.samples.push({ timestamp, duration, delta })
+    this.totalDuration += duration
+    this.totalDelta += delta
+    if (duration > this.maxDuration) {
+      this.maxDuration = duration
+    }
+
+    this.pruneSamples(timestamp)
+  }
+
+  pruneSamples(referenceTime) {
+    const cutoff = referenceTime - this.sampleWindowMs
+    let needsMaxRecalculation = false
+
+    while (this.samples.length > 0 && this.samples[0].timestamp < cutoff) {
+      const expired = this.samples.shift()
+      this.totalDuration -= expired.duration
+      this.totalDelta -= expired.delta
+      if (expired.duration === this.maxDuration) {
+        needsMaxRecalculation = true
+      }
+    }
+
+    if (needsMaxRecalculation) {
+      this.maxDuration = this.samples.reduce((max, sample) => Math.max(max, sample.duration), 0)
+    }
+
+    if (this.totalDuration < 0) this.totalDuration = 0
+    if (this.totalDelta < 0) this.totalDelta = 0
   }
 
   async getStats() {
-    const memUsage = process.memoryUsage()
-    const startCPU = process.cpuUsage()
+    const memoryUsage = process.memoryUsage()
+    const startCpuUsage = process.cpuUsage()
     await new Promise(resolve => setTimeout(resolve, 100))
-    const endCPU = process.cpuUsage(startCPU)
-    const cpuPercent = (endCPU.user + endCPU.system) / 1000 / 100
+    const cpuUsage = process.cpuUsage(startCpuUsage)
+    const cpuPercent = (cpuUsage.user + cpuUsage.system) / 1000 / 100
+
+    const now = getHighResTime()
+    this.pruneSamples(now)
+    const sampleCount = this.samples.length
+    const averageDurationMs = sampleCount ? this.totalDuration / sampleCount : 0
+    const averageDeltaMs = sampleCount ? (this.totalDelta / sampleCount) * 1000 : 0
+    const observedRate = averageDeltaMs > 0 ? 1000 / averageDeltaMs : 0
+    const maxDurationMs = this.maxDuration
+
+    let eventLoop = null
+    if (this.eventLoopMonitor) {
+      const min = toMilliseconds(this.eventLoopMonitor.min)
+      const max = toMilliseconds(this.eventLoopMonitor.max)
+      const mean = toMilliseconds(this.eventLoopMonitor.mean)
+      const p99 = toMilliseconds(this.eventLoopMonitor.percentile?.(99) ?? 0)
+      this.eventLoopMonitor.reset()
+      eventLoop = {
+        minMs: min,
+        maxMs: max,
+        meanMs: mean,
+        p99Ms: p99,
+      }
+    }
+
     return {
       maxMemory: Math.round(os.totalmem() / 1024 / 1024),
-      currentMemory: Math.round(memUsage.rss / 1024 / 1024),
+      currentMemory: Math.round(memoryUsage.rss / 1024 / 1024),
       maxCPU: os.cpus().length * 100,
       currentCPU: cpuPercent,
+      ticks: {
+        sampleCount,
+        windowMs: this.sampleWindowMs,
+        averageDurationMs,
+        maxDurationMs,
+        averageDeltaMs,
+        observedRate,
+      },
+      eventLoop,
     }
   }
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -341,26 +341,66 @@ fastify.get('/zones', async (request, reply) => {
 
 fastify.get('/metrics', async (request, reply) => {
   try {
-    const metrics = []
-    for (const [zoneId, zone] of zones) {
-      const stats = await zone.world.monitor.getStats()
-      metrics.push({
-        id: zoneId,
-        label: zone.config.label,
-        players: zone.world.network.sockets.size,
-        frame: zone.world.frame,
-        time: zone.world.time,
-        networkRate: zone.world.networkRate,
-        cpu: stats.currentCPU,
-        maxCPU: stats.maxCPU,
-        memory: stats.currentMemory,
-        maxMemory: stats.maxMemory,
+    const zoneMetrics = await Promise.all(
+      Array.from(zones.entries()).map(async ([zoneId, zone]) => {
+        const stats = await zone.world.monitor.getStats()
+        const expectedTickRate = (() => {
+          const candidate = zone.config.tickRate ?? zone.world.serverTickRate
+          if (typeof candidate === 'number' && Number.isFinite(candidate) && candidate > 0) {
+            return candidate
+          }
+          return 30
+        })()
+
+        const issues = []
+        if (stats.ticks.sampleCount > 0) {
+          if (stats.ticks.observedRate > 0 && stats.ticks.observedRate < expectedTickRate * 0.9) {
+            issues.push('tick-rate-degraded')
+          }
+          const frameBudgetMs = 1000 / expectedTickRate
+          if (stats.ticks.maxDurationMs > frameBudgetMs * 2) {
+            issues.push('tick-duration-spike')
+          }
+        }
+        if (stats.eventLoop?.p99Ms && stats.eventLoop.p99Ms > 50) {
+          issues.push('event-loop-lag')
+        }
+        if (stats.currentCPU > stats.maxCPU * 0.9) {
+          issues.push('cpu-saturation')
+        }
+        if (stats.currentMemory > stats.maxMemory * 0.9) {
+          issues.push('memory-pressure')
+        }
+
+        return {
+          id: zoneId,
+          label: zone.config.label,
+          players: zone.world.network.sockets.size,
+          frame: zone.world.frame,
+          time: zone.world.time,
+          networkRate: zone.world.networkRate,
+          cpu: stats.currentCPU,
+          maxCPU: stats.maxCPU,
+          memory: stats.currentMemory,
+          maxMemory: stats.maxMemory,
+          ticks: {
+            expectedRate: expectedTickRate,
+            sampleCount: stats.ticks.sampleCount,
+            windowMs: stats.ticks.windowMs,
+            observedRate: stats.ticks.observedRate,
+            averageDurationMs: stats.ticks.averageDurationMs,
+            maxDurationMs: stats.ticks.maxDurationMs,
+            averageDeltaMs: stats.ticks.averageDeltaMs,
+          },
+          eventLoop: stats.eventLoop,
+          issues,
+        }
       })
-    }
+    )
 
     return reply.code(200).send({
       timestamp: new Date().toISOString(),
-      zones: metrics,
+      zones: zoneMetrics,
     })
   } catch (error) {
     console.error('Metrics endpoint failed:', error)

--- a/tests/unit/server-monitor.test.js
+++ b/tests/unit/server-monitor.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import EventEmitter from 'eventemitter3'
+
+let currentNow = 0
+
+const histogram = {
+  min: 0,
+  max: 0,
+  mean: 0,
+  percentile: vi.fn(() => 0),
+  enable: vi.fn(),
+  disable: vi.fn(),
+  reset: vi.fn(() => {
+    histogram.min = 0
+    histogram.max = 0
+    histogram.mean = 0
+  }),
+}
+
+const perfNowMock = vi.fn(() => currentNow)
+const monitorEventLoopDelayMock = vi.fn(() => histogram)
+
+vi.mock('node:perf_hooks', () => ({
+  performance: {
+    now: perfNowMock,
+  },
+  monitorEventLoopDelay: monitorEventLoopDelayMock,
+  __setNow: value => {
+    currentNow = value
+  },
+  __histogram: histogram,
+}))
+
+describe('ServerMonitor', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    currentNow = 0
+    perfNowMock.mockImplementation(() => currentNow)
+    perfNowMock.mockClear()
+    monitorEventLoopDelayMock.mockClear()
+    histogram.enable.mockClear()
+    histogram.disable.mockClear()
+    histogram.reset.mockClear()
+    histogram.percentile.mockReset()
+    histogram.percentile.mockReturnValue(0)
+    histogram.min = 0
+    histogram.max = 0
+    histogram.mean = 0
+    const perfHooks = await import('node:perf_hooks')
+    perfHooks.__setNow(0)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('tracks tick performance and event loop delay statistics', async () => {
+    const perfHooks = await import('node:perf_hooks')
+    const { ServerMonitor } = await import('../../src/core/systems/ServerMonitor.js')
+
+    const world = new EventEmitter()
+    const monitor = new ServerMonitor(world)
+
+    expect(monitorEventLoopDelayMock).toHaveBeenCalledTimes(1)
+
+    monitor.start()
+    expect(histogram.enable).toHaveBeenCalledTimes(1)
+
+    perfHooks.__histogram.min = 2e6
+    perfHooks.__histogram.max = 8e6
+    perfHooks.__histogram.mean = 3e6
+    perfHooks.__histogram.percentile.mockReturnValue(6e6)
+
+    perfHooks.__setNow(0)
+    world.emit('tick', { duration: 4, delta: 0.05 })
+    perfHooks.__setNow(20)
+    world.emit('tick', { duration: 6, delta: 0.04 })
+    perfHooks.__setNow(40)
+    world.emit('tick', { duration: 5, delta: 0.06 })
+
+    const statsPromise = monitor.getStats()
+    await vi.advanceTimersByTimeAsync(100)
+    const stats = await statsPromise
+
+    expect(stats.ticks.sampleCount).toBe(3)
+    expect(stats.ticks.averageDurationMs).toBeCloseTo(5, 5)
+    expect(stats.ticks.maxDurationMs).toBeCloseTo(6, 5)
+    expect(stats.ticks.averageDeltaMs).toBeCloseTo(50, 5)
+    expect(stats.ticks.observedRate).toBeCloseTo(20, 5)
+
+    expect(stats.eventLoop).not.toBeNull()
+    expect(stats.eventLoop?.minMs).toBeCloseTo(2, 5)
+    expect(stats.eventLoop?.maxMs).toBeCloseTo(8, 5)
+    expect(stats.eventLoop?.meanMs).toBeCloseTo(3, 5)
+    expect(stats.eventLoop?.p99Ms).toBeCloseTo(6, 5)
+    expect(histogram.reset).toHaveBeenCalledTimes(1)
+
+    monitor.destroy()
+    expect(histogram.disable).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- instrument the server World tick loop and ServerMonitor to collect high resolution timing and event loop telemetry
- expose richer health data via /metrics and ship a diagnostics CLI plus documentation for interpreting the output
- cover the new monitor pipeline with unit tests and document the observability workflow

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68f91881ec10832d9feaf5fa912fe78b