### PR TITLE
Add worker-task scheduler and deployment preflight automation

### DIFF
--- a/docs/deployment/checklist.md
+++ b/docs/deployment/checklist.md
@@ -11,7 +11,7 @@ Status field during weekly ops reviews.
 | --- | --- | --- | --- | --- |
 | OPS-ENV-001 | Not Started | Provision environment variables via a managed secrets store (Vault, AWS Secrets Manager, Doppler). | GitHub issue `OPS-ENV-001` | Blocks automated rollouts; requires Terraform module ownership defined in [ops runbook](../runbooks/diagnostics-cli.md). |
 | OPS-ENV-002 | Not Started | Define per-environment configuration overlays (dev/staging/prod) with LiveKit URLs, database DSNs, CDN buckets, and signing keys. | GitHub issue `OPS-ENV-002` | Config bundles should align with IaC layouts captured in [`docs/roadmap/hardening-plan.md`](../roadmap/hardening-plan.md). |
-| OPS-ENV-003 | Not Started | Introduce automated drift detection for secrets (Terraform state or rotation alerts). | GitHub issue `OPS-ENV-003` | Surface alerts through the observability pipeline described in [`docs/observability.md`](../observability.md). |
+| OPS-ENV-003 | In Progress | Introduce automated drift detection for secrets (Terraform state or rotation alerts). | GitHub issue `OPS-ENV-003` | Preflight automation (`scripts/ops/preflight.mjs`) now validates required secrets before deployment; integrate with observability alerts next. |
 
 ## Objective OPS-O2 — Infrastructure Automation
 
@@ -78,6 +78,7 @@ This checklist captures the minimum hardening required to move a Hyperfy self-ho
 ## 1. Environment & Secrets Management
 - [x] Provision environment variables through a managed secrets store (Vault, AWS Secrets Manager, Doppler) rather than `.env` files committed to hosts. Refer to `config/environments/*.yaml`, the Terraform/Pulumi secret wiring, and the ExternalSecret/nomad templates for usage examples.
 - [x] Define per-environment configuration overlays (development, staging, production) describing LiveKit URLs, database DSNs, CDN buckets, and signing keys (`config/environments/`).
+- [x] Run the automated deployment preflight (`npm run ops:preflight`) to validate required secrets, world assets, and worker thread readiness before a rollout (`scripts/ops/preflight.mjs`).
 - [ ] Introduce automated drift detection for secrets (e.g., Terraform state or secrets rotation alerts).
 
 ## 2. Infrastructure Automation

--- a/docs/deployment/preflight.md
+++ b/docs/deployment/preflight.md
@@ -1,0 +1,37 @@
+# Deployment Preflight Automation
+
+The `npm run ops:preflight` command executes a lightweight readiness scan
+before promoting a world build to staging or production. It validates critical
+infrastructure expectations without requiring operators to manually check each
+system.
+
+## What the script verifies
+
+1. **Secrets & configuration** – Every environment variable flagged in
+   `config/environments/*.yaml` and the deployment checklist must be present
+   and non-empty before a rollout. Missing values halt the preflight.
+2. **World assets** – Ensures the configured world, assets, and collections
+   directories exist so the server boots with the expected content payloads.
+3. **Build artifacts** – Confirms `build/index.js` is available, catching missed
+   `npm run build` steps in CI or ad-hoc deployments.
+4. **Worker thread readiness** – Spins up the shared `TaskPool` to validate the
+   worker-based quest/metrics scheduler. This catches container runtimes that
+   disable worker threads or misconfigure CPU quotas.
+
+## Running the check
+
+```bash
+npm run ops:preflight
+```
+
+The command emits ✅ passes, ⚠️ warnings, and ❌ blocking failures. The CI/CD
+pipeline should fail if any blocking failures are reported.
+
+## Extending the script
+
+- Wire additional checks into `scripts/ops/preflight.mjs`, such as database
+  migrations, CDN write access, or observability endpoints.
+- Export metrics from the preflight into your monitoring stack so repeated
+  failures surface as alerts.
+- Pair the script with infrastructure drift detection (OPS-ENV-003) to close the
+  loop between pre-deployment validation and long-term secrets governance.

--- a/docs/mmorpg-roadmap.md
+++ b/docs/mmorpg-roadmap.md
@@ -9,6 +9,7 @@ This document outlines concrete engineering initiatives that would move Hyperfy 
 - **Realtime networking upgrades** – Extend `ServerNetwork` with replication throttling, prioritised interest management, and configurable tick rates per zone so updates scale with population instead of broadcasting every packet to all sockets.【F:src/core/systems/ServerNetwork.js†L84-L124】【F:src/core/systems/Server.js†L3-L30】
   - _Status update:_ Player replication now respects per-zone throttling budgets with distance-based prioritisation, configurable via new `SERVER_NETWORK_*` settings, dramatically reducing cross-zone broadcast chatter.【F:src/core/systems/ServerNetwork.js†L31-L214】【F:src/server/config.js†L108-L167】
 - **Resilience & observability** – Introduce health probes, autoscaling signals, and crash recovery for each service. Capture structured telemetry for tick time, bandwidth, and error rates to feed capacity planning and incident response.【F:src/server/index.js†L139-L181】
+  - _Status update:_ Background compute now runs through the worker-thread task pool and `ServerTaskQueue`, enabling parallel quest evaluation and metrics aggregation while preserving single-threaded simulation safety.【F:src/server/runtime/TaskPool.js†L1-L141】【F:src/core/systems/ServerTaskQueue.js†L1-L38】
 
 ## 2. Persistence & Progression
 
@@ -20,6 +21,7 @@ This document outlines concrete engineering initiatives that would move Hyperfy 
 
 - **Combat & abilities** – Build authoritative combat resolvers, cooldown management, and effect pipelines with deterministic rollback, rather than trusting client-reported actions.
 - **Quest & narrative tools** – Provide designers with node-based quest editors and live scripting hooks (building on the existing app system) so narrative content can ship rapidly.【F:README.md†L12-L99】
+  - _Status update:_ `ServerQuests` orchestrates progress tracking with deterministic worker-backed simulations, giving narrative designers a baseline quest state machine tied to persistence and player inventory services.【F:src/core/systems/ServerQuests.js†L1-L92】【F:src/core/systems/ServerCharacters.js†L213-L280】
 - **Social layers** – Expand chat, guilds, parties, and matchmaking using scalable messaging backends, plus moderation workflows for reports, muting, and ban appeals.
 
 ## 4. World Building & Content Pipeline
@@ -32,6 +34,7 @@ This document outlines concrete engineering initiatives that would move Hyperfy 
 
 - **High-fidelity renderer** – Augment the WebGL renderer with WebGPU or native clients to unlock large crowds, advanced lighting, and platform-specific optimisations beyond the current AO/bloom stack.【F:src/core/systems/ClientGraphics.js†L1-L200】【F:docs/DEPLOYMENT_STATUS.md†L15-L35】
 - **Input & accessibility** – Layer on action combat controls, controller support, remappable keybinds, and accessibility features (UI scaling, color blindness filters) for broad audiences.
+  - _Status update:_ The command palette now ships with keyboard navigation, fuzzy ranking, and accent-aware highlighting, setting the foundation for richer accessibility tooling and theming integrations.【F:src/client/components/CommandPalette.js†L1-L233】【F:src/client/components/commandPaletteUtils.js†L1-L56】
 - **Performance budgets** – Enforce strict per-frame budgets through frame graph instrumentation, asset streaming hints, and fallback quality tiers for low-end devices.
 
 ## 6. DevOps & Compliance

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "node-client:dev": "node scripts/build-node-client.mjs --dev",
     "node-client:build": "node scripts/build-node-client.mjs",
     "diagnostics": "node scripts/server-diagnostics.mjs",
+    "ops:preflight": "node scripts/ops/preflight.mjs",
     "lint": "eslint . --ext .js,.jsx",
     "lint:fix": "eslint . --ext .js,.jsx --fix",
     "format": "prettier --write .",

--- a/scripts/ops/preflight.mjs
+++ b/scripts/ops/preflight.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { constants as fsConstants } from 'node:fs'
+import { access } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
+import { getServerConfig } from '../../src/server/config.js'
+import { TaskPool } from '../../src/server/runtime/TaskPool.js'
+
+const checks = []
+
+function record(status, title, detail = '') {
+  checks.push({ status, title, detail })
+  const symbol = status === 'pass' ? '✅' : status === 'warn' ? '⚠️' : '❌'
+  const message = detail ? `${title} — ${detail}` : title
+  if (status === 'pass') {
+    console.log(`${symbol} ${message}`)
+  } else if (status === 'warn') {
+    console.warn(`${symbol} ${message}`)
+  } else {
+    console.error(`${symbol} ${message}`)
+  }
+}
+
+async function verifyEnvVariables(vars) {
+  const missing = vars.filter(name => {
+    const value = process.env[name]
+    return value === undefined || value === null || String(value).trim() === ''
+  })
+  if (missing.length === 0) {
+    record('pass', 'Environment variables present', vars.join(', '))
+  } else {
+    record('fail', 'Missing required environment variables', missing.join(', '))
+  }
+}
+
+async function verifyPath(label, targetPath) {
+  try {
+    await access(targetPath, fsConstants.R_OK)
+    record('pass', `${label} accessible`, targetPath)
+  } catch (error) {
+    record('fail', `${label} missing`, `${targetPath} (${error.message})`)
+  }
+}
+
+async function verifyTaskPool() {
+  const pool = new TaskPool({ size: Math.min(2, Math.max(1, (os.cpus()?.length ?? 1) - 1)) })
+  try {
+    const result = await pool.run('metrics:aggregate-frames', {
+      frames: [
+        { durationMs: 4.2 },
+        { durationMs: 5.6 },
+      ],
+    })
+    if (!Number.isFinite(result.averageDuration)) {
+      throw new Error('Invalid average duration from task pool')
+    }
+    record('pass', 'Worker thread task pool online', `avg tick duration ${result.averageDuration.toFixed(2)}ms`)
+  } catch (error) {
+    record('fail', 'Worker thread task pool failed', error.message)
+  } finally {
+    await pool.destroy()
+  }
+}
+
+async function main() {
+  console.log('🧪 Hyperfy deployment preflight checks')
+  console.log('------------------------------------')
+
+  const requiredEnv = [
+    'WORLD',
+    'FASTIFY_JWT_SECRET',
+    'FASTIFY_ADMIN_CODE',
+    'LIVEKIT_API_KEY',
+    'LIVEKIT_API_SECRET',
+    'DATABASE_URL',
+    'CDN_BUCKET_NAME',
+    'CDN_SIGNING_KEY',
+  ]
+  await verifyEnvVariables(requiredEnv)
+
+  try {
+    const config = getServerConfig()
+    record('pass', 'Server configuration parsed', `world=${config.world.dir}`)
+    await verifyPath('World directory', config.world.dir)
+    await verifyPath('Assets directory', config.world.assetsDir)
+    await verifyPath('Collections directory', config.world.collectionsDir)
+  } catch (error) {
+    record('fail', 'Server configuration failed', error.message)
+  }
+
+  const buildOutput = path.join(process.cwd(), 'build', 'index.js')
+  await verifyPath('Build output', buildOutput)
+
+  await verifyTaskPool()
+
+  const failed = checks.filter(check => check.status === 'fail')
+  const warned = checks.filter(check => check.status === 'warn')
+
+  console.log('------------------------------------')
+  if (failed.length === 0) {
+    if (warned.length === 0) {
+      console.log('✅ Preflight completed with no blocking issues.')
+    } else {
+      console.log(`⚠️ Preflight completed with ${warned.length} warnings.`)
+    }
+  } else {
+    console.error(`❌ Preflight failed with ${failed.length} blocking issue(s).`)
+    process.exitCode = 1
+  }
+}
+
+main().catch(error => {
+  console.error('❌ Preflight crashed:', error)
+  process.exitCode = 1
+})

--- a/src/client/components/CommandPalette.js
+++ b/src/client/components/CommandPalette.js
@@ -4,9 +4,12 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { bindingToHumanReadable } from '../utils/inputBindings'
 import { Portal } from './Portal'
 import { useFocusTrap } from './useFocusTrap'
+import { highlightMatch, scoreCommands } from './commandPaletteUtils'
 
 export function CommandPalette({ open, onClose, commands = [], onRun }) {
   const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
   const listRef = useRef(null)
   const inputRef = useRef(null)
   useFocusTrap(listRef, { active: open })
@@ -14,6 +17,7 @@ export function CommandPalette({ open, onClose, commands = [], onRun }) {
   useEffect(() => {
     if (!open) {
       setQuery('')
+      setActiveIndex(0)
       return
     }
     const timeout = setTimeout(() => {
@@ -24,31 +28,80 @@ export function CommandPalette({ open, onClose, commands = [], onRun }) {
   }, [open])
 
   useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const update = () => setPrefersReducedMotion(mediaQuery.matches)
+    update()
+    mediaQuery.addEventListener('change', update)
+    return () => mediaQuery.removeEventListener('change', update)
+  }, [])
+
+  const scored = useMemo(() => scoreCommands(commands, query), [commands, query])
+
+  const filteredFlat = useMemo(() => scored.map(entry => entry.command), [scored])
+
+  const grouped = useMemo(() => {
+    if (filteredFlat.length === 0) return []
+    const groups = new Map()
+    for (const command of filteredFlat) {
+      const groupName = command.group ?? 'Commands'
+      if (!groups.has(groupName)) {
+        groups.set(groupName, [])
+      }
+      groups.get(groupName).push(command)
+    }
+    return Array.from(groups.entries()).map(([name, items]) => ({ name, items }))
+  }, [filteredFlat])
+
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [grouped.length, query])
+
+  useEffect(() => {
     if (!open) return
     const handleKeyDown = event => {
       if (event.key === 'Escape') {
         event.preventDefault()
         onClose?.()
+      } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        setActiveIndex(current => {
+          const next = event.key === 'ArrowDown' ? current + 1 : current - 1
+          if (next < 0) return Math.max(filteredFlat.length - 1, 0)
+          if (next >= filteredFlat.length) return 0
+          return next
+        })
+      } else if (event.key === 'Enter') {
+        const active = filteredFlat[activeIndex]
+        if (active) {
+          onRun?.(active)
+          onClose?.()
+        }
       }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [open, onClose])
-
-  const filtered = useMemo(() => {
-    if (!query) return commands
-    const q = query.toLowerCase().trim()
-    if (!q) return commands
-    return commands.filter(cmd => {
-      return (
-        cmd.title?.toLowerCase().includes(q) ||
-        cmd.description?.toLowerCase().includes(q) ||
-        cmd.tags?.some(tag => tag.toLowerCase().includes(q))
-      )
-    })
-  }, [commands, query])
+  }, [activeIndex, filteredFlat, onClose, onRun, open])
 
   if (!open) return null
+
+  const animationStyles = prefersReducedMotion
+    ? ''
+    : `
+        transform: translateY(-8px);
+        opacity: 0;
+        animation: commandpalette-enter 150ms var(--hf-motion-ease-emphasized) forwards;
+
+        @keyframes commandpalette-enter {
+          from {
+            transform: translateY(-8px);
+            opacity: 0;
+          }
+          to {
+            transform: translateY(0);
+            opacity: 1;
+          }
+        }
+      `
 
   return (
     <Portal>
@@ -87,7 +140,7 @@ export function CommandPalette({ open, onClose, commands = [], onRun }) {
             display: flex;
             flex-direction: column;
             overflow: hidden;
-            transition: transform var(--hf-motion-duration-medium) var(--hf-motion-ease-standard);
+            ${animationStyles}
           `}
         >
           <label
@@ -115,6 +168,23 @@ export function CommandPalette({ open, onClose, commands = [], onRun }) {
               aria-label='Search commands'
               value={query}
               onChange={event => setQuery(event.target.value)}
+              onKeyDown={event => {
+                if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+                  event.preventDefault()
+                  setActiveIndex(current => {
+                    const next = event.key === 'ArrowDown' ? current + 1 : current - 1
+                    if (next < 0) return Math.max(filteredFlat.length - 1, 0)
+                    if (next >= filteredFlat.length) return 0
+                    return next
+                  })
+                } else if (event.key === 'Enter') {
+                  const active = filteredFlat[activeIndex]
+                  if (active) {
+                    onRun?.(active)
+                    onClose?.()
+                  }
+                }
+              }}
               placeholder='Type to filter commands'
               css={css`
                 flex: 1;
@@ -134,7 +204,7 @@ export function CommandPalette({ open, onClose, commands = [], onRun }) {
               overflow-y: auto;
             `}
           >
-            {filtered.length === 0 && (
+            {filteredFlat.length === 0 && (
               <li
                 css={css`
                   padding: 1.5rem 1.25rem;
@@ -145,68 +215,137 @@ export function CommandPalette({ open, onClose, commands = [], onRun }) {
                 No commands match “{query}”.
               </li>
             )}
-            {filtered.map(cmd => (
-              <li key={cmd.id}>
-                <button
-                  type='button'
-                  onClick={() => {
-                    onRun?.(cmd)
-                    onClose?.()
-                  }}
+            {grouped.map(group => (
+              <li key={group.name}>
+                <div
                   css={css`
-                    display: flex;
-                    align-items: center;
-                    justify-content: space-between;
-                    gap: 1rem;
-                    width: 100%;
-                    border: none;
-                    background: none;
-                    padding: 0.9rem 1.25rem;
-                    text-align: left;
-                    color: inherit;
-                    cursor: pointer;
-                    transition: background-color var(--hf-motion-duration-fast) var(--hf-motion-ease-standard);
-                    &:hover,
-                    &:focus-visible {
-                      background: var(--hf-color-interaction-hover);
-                    }
+                    padding: 0.75rem 1.25rem 0.25rem;
+                    font-size: var(--hf-font-size-xs);
+                    letter-spacing: 0.08em;
+                    text-transform: uppercase;
+                    color: var(--hf-color-text-muted);
                   `}
                 >
-                  <div
-                    css={css`
-                      display: flex;
-                      flex-direction: column;
-                      gap: 0.25rem;
-                    `}
-                  >
-                    <span
-                      css={css`
-                        font-size: var(--hf-font-size);
-                        color: var(--hf-color-heading);
-                      `}
-                    >
-                      {cmd.title}
-                    </span>
-                    {cmd.description && (
-                      <span
-                        css={css`
-                          font-size: var(--hf-font-size-sm);
-                          color: var(--hf-color-text-muted);
-                        `}
-                      >
-                        {cmd.description}
-                      </span>
-                    )}
-                  </div>
-                  <span
-                    css={css`
-                      font-size: var(--hf-font-size-sm);
-                      color: var(--hf-color-text-muted);
-                    `}
-                  >
-                    {bindingToHumanReadable(cmd.shortcut)}
-                  </span>
-                </button>
+                  {group.name}
+                </div>
+                <ul
+                  css={css`
+                    list-style: none;
+                    margin: 0;
+                    padding: 0;
+                  `}
+                >
+                  {group.items.map(command => {
+                    const flatIndex = filteredFlat.indexOf(command)
+                    const isActive = flatIndex === activeIndex
+                    return (
+                      <li key={command.id}>
+                        <button
+                          type='button'
+                          onMouseEnter={() => setActiveIndex(flatIndex)}
+                          onFocus={() => setActiveIndex(flatIndex)}
+                          onClick={() => {
+                            onRun?.(command)
+                            onClose?.()
+                          }}
+                          css={css`
+                            display: flex;
+                            align-items: center;
+                            justify-content: space-between;
+                            gap: 1rem;
+                            width: 100%;
+                            border: none;
+                            background: none;
+                            padding: 0.9rem 1.25rem;
+                            text-align: left;
+                            color: inherit;
+                            cursor: pointer;
+                            position: relative;
+                            transition: background-color var(--hf-motion-duration-fast) var(--hf-motion-ease-standard);
+                            ${isActive ? 'background: var(--hf-color-interaction-hover);' : ''}
+                          `}
+                        >
+                          <div
+                            css={css`
+                              display: flex;
+                              flex-direction: column;
+                              gap: 0.25rem;
+                            `}
+                          >
+                            <span
+                              css={css`
+                                font-size: var(--hf-font-size);
+                                color: var(--hf-color-heading);
+                                display: flex;
+                                align-items: center;
+                                gap: 0.5rem;
+                              `}
+                            >
+                              {command.icon && <command.icon width={16} height={16} aria-hidden='true' />}
+                              {highlightMatch(command.title ?? '', query).map((segment, index) => (
+                                <span
+                                  key={index}
+                                  css={segment.highlight ? css`color: var(--hf-color-accent);` : undefined}
+                                >
+                                  {segment.text}
+                                </span>
+                              ))}
+                            </span>
+                            {command.description && (
+                              <span
+                                css={css`
+                                  font-size: var(--hf-font-size-sm);
+                                  color: var(--hf-color-text-muted);
+                                `}
+                              >
+                                {highlightMatch(command.description, query).map((segment, index) => (
+                                  <span
+                                    key={index}
+                                    css={segment.highlight ? css`color: var(--hf-color-accent-muted);` : undefined}
+                                  >
+                                    {segment.text}
+                                  </span>
+                                ))}
+                              </span>
+                            )}
+                            {command.tags?.length > 0 && (
+                              <div
+                                css={css`
+                                  display: flex;
+                                  flex-wrap: wrap;
+                                  gap: 0.35rem;
+                                `}
+                              >
+                                {command.tags.map(tag => (
+                                  <span
+                                    key={tag}
+                                    css={css`
+                                      font-size: var(--hf-font-size-xs);
+                                      padding: 0.1rem 0.4rem;
+                                      border-radius: 999px;
+                                      background: var(--hf-color-surface-raised);
+                                      color: var(--hf-color-text-muted);
+                                    `}
+                                  >
+                                    {tag}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                          <span
+                            css={css`
+                              font-size: var(--hf-font-size-sm);
+                              color: var(--hf-color-text-muted);
+                            `}
+                          >
+                            {bindingToHumanReadable(command.shortcut)}
+                          </span>
+                        </button>
+                      </li>
+                    )
+                  })}
+                </ul>
               </li>
             ))}
           </ul>

--- a/src/client/components/commandPaletteUtils.js
+++ b/src/client/components/commandPaletteUtils.js
@@ -1,0 +1,61 @@
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function scoreCommands(commands, rawQuery) {
+  const query = rawQuery?.trim()?.toLowerCase() ?? ''
+  if (!query) {
+    return commands.map((command, index) => ({ command, score: 0, index }))
+  }
+  return commands
+    .map((command, index) => {
+      const haystacks = [command.title, command.description, ...(command.tags ?? []), command.group]
+        .filter(Boolean)
+        .map(value => String(value).toLowerCase())
+      let bestScore = -Infinity
+      for (const haystack of haystacks) {
+        const position = haystack.indexOf(query)
+        if (position === -1) continue
+        const score = 100 - position * 2
+        bestScore = Math.max(bestScore, score)
+      }
+      const startsWith = command.title?.toLowerCase().startsWith(query)
+      if (startsWith) {
+        bestScore = Math.max(bestScore, 200 - query.length)
+      }
+      if (command.tags?.some(tag => tag.toLowerCase() === query)) {
+        bestScore = Math.max(bestScore, 150)
+      }
+      return { command, score: bestScore, index }
+    })
+    .filter(entry => entry.score > -Infinity)
+    .sort((a, b) => {
+      if (b.score === a.score) {
+        return a.index - b.index
+      }
+      return b.score - a.score
+    })
+}
+
+export function highlightMatch(text, rawQuery) {
+  const safeText = text ?? ''
+  const query = rawQuery?.trim()
+  if (!query) {
+    return [{ text: safeText, highlight: false }]
+  }
+  const pattern = new RegExp(`(${escapeRegExp(query)})`, 'ig')
+  const segments = []
+  let lastIndex = 0
+  let match
+  while ((match = pattern.exec(safeText)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ text: safeText.slice(lastIndex, match.index), highlight: false })
+    }
+    segments.push({ text: match[0], highlight: true })
+    lastIndex = pattern.lastIndex
+  }
+  if (lastIndex < safeText.length) {
+    segments.push({ text: safeText.slice(lastIndex), highlight: false })
+  }
+  return segments.length > 0 ? segments : [{ text: safeText, highlight: false }]
+}

--- a/src/core/createServerWorld.js
+++ b/src/core/createServerWorld.js
@@ -7,9 +7,12 @@ import { ServerCharacters } from './systems/ServerCharacters'
 import { NodeLoader } from './systems/NodeLoader'
 import { ServerEnvironment } from './systems/ServerEnvironment'
 import { ServerMonitor } from './systems/ServerMonitor'
+import { ServerTaskQueue } from './systems/ServerTaskQueue'
+import { ServerQuests } from './systems/ServerQuests'
 
 export function createServerWorld() {
   const world = new World()
+  world.register('tasks', ServerTaskQueue)
   world.register('server', Server)
   world.register('livekit', ServerLiveKit)
   world.register('network', ServerNetwork)
@@ -17,5 +20,6 @@ export function createServerWorld() {
   world.register('environment', ServerEnvironment)
   world.register('monitor', ServerMonitor)
   world.register('characters', ServerCharacters)
+  world.register('quests', ServerQuests)
   return world
 }

--- a/src/core/systems/ServerCharacters.js
+++ b/src/core/systems/ServerCharacters.js
@@ -300,7 +300,41 @@ export class ServerCharacters extends System {
       }
       await this.db('character_quests').insert(row)
     }
-    const entry = mapQuestRow(row)
+    let entry = mapQuestRow(row)
+    const questSystem = this.world?.quests
+    if (questSystem) {
+      try {
+        const { state: enriched } = await questSystem.enrichQuestState(
+          {
+            questId,
+            status: entry.status,
+            progress: entry.progress,
+          },
+          { events: Array.isArray(data.events) ? data.events : [] }
+        )
+        if (enriched) {
+          const didChangeStatus = enriched.status && enriched.status !== entry.status
+          const didChangeProgress = JSON.stringify(enriched.progress ?? {}) !== JSON.stringify(entry.progress ?? {})
+          entry = {
+            ...entry,
+            status: enriched.status ?? entry.status,
+            progress: enriched.progress ?? entry.progress,
+          }
+          if (didChangeStatus || didChangeProgress) {
+            await this.db('character_quests')
+              .where({ id: row.id })
+              .update({
+                status: entry.status,
+                progress: JSON.stringify(entry.progress ?? {}),
+                updatedAt: now,
+              })
+            row = { ...row, status: entry.status, progress: JSON.stringify(entry.progress ?? {}), updatedAt: now }
+          }
+        }
+      } catch (error) {
+        console.warn('[ServerCharacters] Failed to enrich quest state', { questId, error })
+      }
+    }
     const character = await this.getCharacterById(characterId)
     if (character) {
       const index = character.quests.findIndex(quest => quest.questId === questId)

--- a/src/core/systems/ServerQuests.js
+++ b/src/core/systems/ServerQuests.js
@@ -1,0 +1,104 @@
+import { System } from './System'
+import { taskHandlers } from '../../server/runtime/task-handlers.js'
+
+const builtinQuestDefinitions = [
+  Object.freeze({
+    id: 'welcome-to-hyperfy',
+    title: 'Welcome to Hyperfy',
+    description: 'Orient new players and ensure they learn core traversal mechanics.',
+    category: 'onboarding',
+    steps: [
+      { id: 'speak-to-guide', type: 'talk', count: 1, description: 'Speak to the onboarding guide in the plaza.' },
+      { id: 'visit-builder', type: 'visit', count: 1, description: 'Walk to the creator terminal to unlock build mode.' },
+      { id: 'collect-resource', type: 'collect', count: 3, description: 'Gather three ether seeds scattered around spawn.' },
+    ],
+    rewards: {
+      experience: 250,
+      currency: 100,
+      unlocks: ['builder-mode'],
+    },
+  }),
+  Object.freeze({
+    id: 'first-encounter',
+    title: 'First Encounter',
+    description: 'Teach basic combat awareness with a safe holosim encounter.',
+    category: 'combat',
+    steps: [
+      { id: 'equip-weapon', type: 'interact', count: 1, description: 'Equip the default resonator from your inventory.' },
+      { id: 'defeat-holos', type: 'defeat', count: 5, description: 'Defeat five holoforms spawned by the arena console.' },
+    ],
+    rewards: {
+      experience: 400,
+      items: [{ itemId: 'resonator-mk2', quantity: 1 }],
+    },
+  }),
+]
+
+function clone(value) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value)
+  }
+  return JSON.parse(JSON.stringify(value))
+}
+
+export class ServerQuests extends System {
+  constructor(world) {
+    super(world)
+    this.definitions = new Map()
+  }
+
+  async init(options = {}) {
+    const customDefinitions = Array.isArray(options.questDefinitions) ? options.questDefinitions : []
+    this.reloadDefinitions([...builtinQuestDefinitions, ...customDefinitions])
+  }
+
+  reloadDefinitions(definitions = []) {
+    this.definitions.clear()
+    for (const definition of definitions) {
+      if (!definition?.id) continue
+      const entry = {
+        ...definition,
+        steps: Array.isArray(definition.steps) ? definition.steps.map(step => ({ ...step })) : [],
+      }
+      this.definitions.set(entry.id, Object.freeze(entry))
+    }
+  }
+
+  getDefinition(questId) {
+    return this.definitions.get(questId) ?? null
+  }
+
+  listDefinitions() {
+    return Array.from(this.definitions.values())
+  }
+
+  async enrichQuestState(state = {}, options = {}) {
+    const questId = state.questId ?? options.questId
+    if (!questId) return { state, summary: null }
+    const definition = this.getDefinition(questId)
+    if (!definition) {
+      return { state, summary: null }
+    }
+    const progress = clone(state.progress ?? {})
+    const payload = {
+      definition,
+      progress,
+      events: options.events ?? [],
+    }
+    const executor = this.world?.tasks
+    let result
+    if (executor?.run) {
+      result = await executor.run('quest:simulate-progress', payload)
+    } else {
+      const handler = taskHandlers.get('quest:simulate-progress')
+      result = await handler(payload)
+    }
+    const nextState = {
+      ...state,
+      questId,
+      status: result.summary?.status ?? state.status ?? 'active',
+      progress: result.progress,
+    }
+    return { state: nextState, summary: result.summary }
+  }
+}

--- a/src/core/systems/ServerTaskQueue.js
+++ b/src/core/systems/ServerTaskQueue.js
@@ -1,0 +1,43 @@
+import { System } from './System'
+import { TaskPool } from '../../server/runtime/TaskPool.js'
+
+export class ServerTaskQueue extends System {
+  constructor(world) {
+    super(world)
+    this.pool = null
+    this.metrics = {
+      tasksExecuted: 0,
+      tasksFailed: 0,
+      lastFailure: null,
+    }
+  }
+
+  async init(options = {}) {
+    const inlineFallback = options.forceInline === true
+    this.pool = new TaskPool({ inlineFallback })
+  }
+
+  async destroy() {
+    await this.pool?.destroy()
+    this.pool = null
+  }
+
+  async run(taskName, payload) {
+    if (!this.pool) {
+      throw new Error('ServerTaskQueue has not been initialised')
+    }
+    try {
+      const result = await this.pool.run(taskName, payload)
+      this.metrics.tasksExecuted++
+      return result
+    } catch (error) {
+      this.metrics.tasksFailed++
+      this.metrics.lastFailure = {
+        at: Date.now(),
+        taskName,
+        message: error?.message ?? 'Unknown error',
+      }
+      throw error
+    }
+  }
+}

--- a/src/server/runtime/TaskPool.js
+++ b/src/server/runtime/TaskPool.js
@@ -1,0 +1,163 @@
+import os from 'node:os'
+import { Worker } from 'node:worker_threads'
+
+import { hasTaskHandler, taskHandlers } from './task-handlers.js'
+
+let globalJobId = 0
+
+function createWorker() {
+  return new Worker(new URL('./task-worker.js', import.meta.url), {
+    type: 'module',
+  })
+}
+
+function formatWorkerError(error, taskName) {
+  if (!error) {
+    return new Error(`Worker exited unexpectedly while running task "${taskName}"`)
+  }
+  if (error instanceof Error) {
+    return error
+  }
+  const err = new Error(error.message ?? `Worker failed while running task "${taskName}"`)
+  if (error.stack) {
+    err.stack = error.stack
+  }
+  err.code = error.code
+  return err
+}
+
+export class TaskPool {
+  constructor(options = {}) {
+    const cpuCount = os.cpus()?.length ?? 1
+    const desiredSize = options.size ?? Math.max(1, Math.min(cpuCount - 1, 4))
+    this.size = Math.max(1, desiredSize)
+    this.inlineFallback = options.inlineFallback ?? false
+    this.idle = []
+    this.queue = []
+    this.pending = new Map()
+    this.workers = new Set()
+    this.destroyed = false
+
+    if (!this.inlineFallback) {
+      for (let index = 0; index < this.size; index++) {
+        this.#spawnWorker()
+      }
+    }
+  }
+
+  async run(taskName, payload) {
+    if (this.destroyed) {
+      throw new Error('TaskPool has been destroyed')
+    }
+    if (!hasTaskHandler(taskName)) {
+      throw new Error(`Unknown task "${taskName}"`)
+    }
+    if (this.inlineFallback || this.workers.size === 0) {
+      return taskHandlers.get(taskName)(payload)
+    }
+    const jobId = globalJobId++
+    return new Promise((resolve, reject) => {
+      const job = { id: jobId, taskName, payload, resolve, reject, worker: null }
+      this.queue.push(job)
+      this.#drain()
+    })
+  }
+
+  async destroy() {
+    this.destroyed = true
+    for (const worker of this.workers) {
+      worker.removeAllListeners()
+      await worker.terminate()
+    }
+    this.workers.clear()
+    this.idle.length = 0
+    for (const [, job] of this.pending) {
+      job.reject(new Error('Task cancelled due to pool destruction'))
+    }
+    this.pending.clear()
+    this.queue.length = 0
+  }
+
+  #spawnWorker() {
+    try {
+      const worker = createWorker()
+      worker.on('message', message => {
+        this.#handleMessage(worker, message)
+      })
+      worker.on('error', error => {
+        this.#handleWorkerFailure(worker, error)
+      })
+      worker.on('exit', code => {
+        if (!this.destroyed && code !== 0) {
+          this.#handleWorkerFailure(worker, new Error(`Worker exited with code ${code}`))
+        }
+      })
+      this.workers.add(worker)
+      this.idle.push(worker)
+      this.#drain()
+    } catch (error) {
+      this.inlineFallback = true
+      console.warn('[TaskPool] Falling back to inline execution:', error)
+    }
+  }
+
+  #drain() {
+    if (this.inlineFallback) return
+    while (this.queue.length > 0 && this.idle.length > 0) {
+      const job = this.queue.shift()
+      const worker = this.idle.pop()
+      if (!worker) break
+      job.worker = worker
+      this.pending.set(job.id, job)
+      worker.postMessage({
+        id: job.id,
+        taskName: job.taskName,
+        payload: job.payload,
+      })
+    }
+  }
+
+  #handleMessage(worker, message) {
+    if (!message || typeof message.id !== 'number') {
+      return
+    }
+    const job = this.pending.get(message.id)
+    if (!job) {
+      return
+    }
+    this.pending.delete(message.id)
+    if (!this.destroyed) {
+      this.idle.push(worker)
+    }
+    if (message.error) {
+      job.reject(formatWorkerError(message.error, job.taskName))
+    } else {
+      job.resolve(message.result)
+    }
+    this.#drain()
+  }
+
+  #handleWorkerFailure(worker, error) {
+    if (this.destroyed) return
+    for (const [id, job] of this.pending.entries()) {
+      if (job.worker === worker) {
+        this.pending.delete(id)
+        this.queue.unshift(job)
+      }
+    }
+    this.workers.delete(worker)
+    const index = this.idle.indexOf(worker)
+    if (index >= 0) {
+      this.idle.splice(index, 1)
+    }
+    if (this.workers.size === 0) {
+      this.inlineFallback = true
+    } else if (!this.inlineFallback) {
+      this.#spawnWorker()
+    }
+    if (error) {
+      console.warn('[TaskPool] Worker failure:', error)
+    }
+    this.#drain()
+  }
+}

--- a/src/server/runtime/task-handlers.js
+++ b/src/server/runtime/task-handlers.js
@@ -1,0 +1,113 @@
+import { createHash } from 'node:crypto'
+
+const QUEST_STEP_TYPES = new Set(['collect', 'visit', 'defeat', 'interact', 'talk'])
+
+function normaliseProgress(definition, progress = {}) {
+  const normalised = { ...progress }
+  for (const step of definition.steps ?? []) {
+    if (!normalised[step.id]) {
+      normalised[step.id] = {
+        count: 0,
+        completed: false,
+        lastEvent: null,
+      }
+    }
+  }
+  return normalised
+}
+
+function applyQuestEvent(definition, progress, event) {
+  if (!event || typeof event !== 'object') return progress
+  const { stepId, type, amount = 1, metadata = {} } = event
+  const targetStep = definition.steps?.find(step => step.id === stepId)
+  if (!targetStep) return progress
+  if (targetStep.type && targetStep.type !== type && QUEST_STEP_TYPES.has(targetStep.type)) {
+    return progress
+  }
+  const entry = progress[stepId] ?? {
+    count: 0,
+    completed: false,
+    lastEvent: null,
+  }
+  const required = targetStep.count ?? 1
+  const increment = Number.isFinite(amount) ? amount : 1
+  const nextCount = Math.max(0, entry.count + increment)
+  const completed = nextCount >= required
+  progress[stepId] = {
+    ...entry,
+    count: completed ? required : nextCount,
+    completed,
+    lastEvent: {
+      at: metadata.at ?? Date.now(),
+      description: metadata.description ?? null,
+    },
+  }
+  return progress
+}
+
+function evaluateQuest(definition, progress) {
+  const summary = {
+    stepsCompleted: 0,
+    stepsTotal: definition.steps?.length ?? 0,
+    status: 'active',
+  }
+  if (!definition.steps || definition.steps.length === 0) {
+    summary.status = 'ready-to-turn-in'
+    return summary
+  }
+  for (const step of definition.steps) {
+    const entry = progress[step.id]
+    if (!entry) continue
+    if (entry.completed) {
+      summary.stepsCompleted++
+    }
+  }
+  if (summary.stepsCompleted >= summary.stepsTotal && summary.stepsTotal > 0) {
+    summary.status = 'ready-to-turn-in'
+  }
+  return summary
+}
+
+async function simulateQuest(payload = {}) {
+  const definition = payload.definition ?? { steps: [] }
+  const baseProgress = normaliseProgress(definition, payload.progress)
+  const events = Array.isArray(payload.events) ? payload.events : []
+  const progress = { ...baseProgress }
+  for (const event of events) {
+    applyQuestEvent(definition, progress, event)
+  }
+  const summary = evaluateQuest(definition, progress)
+  return {
+    progress,
+    summary,
+  }
+}
+
+async function aggregateMetrics(payload = {}) {
+  const frames = Array.isArray(payload.frames) ? payload.frames : []
+  let totalDuration = 0
+  let maxDuration = 0
+  for (const frame of frames) {
+    if (!frame) continue
+    const duration = Number(frame.durationMs ?? 0)
+    if (!Number.isFinite(duration)) continue
+    totalDuration += duration
+    maxDuration = Math.max(maxDuration, duration)
+  }
+  const averageDuration = frames.length ? totalDuration / frames.length : 0
+  const checksum = createHash('sha256').update(JSON.stringify(payload)).digest('hex')
+  return {
+    averageDuration,
+    maxDuration,
+    checksum,
+  }
+}
+
+export const taskHandlers = new Map([
+  ['quest:simulate-progress', simulateQuest],
+  ['metrics:aggregate-frames', aggregateMetrics],
+])
+
+export function hasTaskHandler(name) {
+  return taskHandlers.has(name)
+}

--- a/src/server/runtime/task-worker.js
+++ b/src/server/runtime/task-worker.js
@@ -1,0 +1,44 @@
+import { parentPort } from 'node:worker_threads'
+import { taskHandlers } from './task-handlers.js'
+
+if (!parentPort) {
+  throw new Error('Task worker must be executed as a worker thread')
+}
+
+parentPort.on('message', async message => {
+  const { id, taskName, payload } = message ?? {}
+  if (typeof id !== 'number') {
+    parentPort.postMessage({
+      id,
+      error: {
+        message: 'Task message missing numeric id',
+        code: 'ERR_INVALID_MESSAGE',
+      },
+    })
+    return
+  }
+  if (!taskHandlers.has(taskName)) {
+    parentPort.postMessage({
+      id,
+      error: {
+        message: `Unknown task "${taskName}"`,
+        code: 'ERR_UNKNOWN_TASK',
+      },
+    })
+    return
+  }
+  const handler = taskHandlers.get(taskName)
+  try {
+    const result = await handler(payload)
+    parentPort.postMessage({ id, result })
+  } catch (error) {
+    parentPort.postMessage({
+      id,
+      error: {
+        message: error?.message ?? 'Task execution failed',
+        code: error?.code ?? 'ERR_TASK_FAILED',
+        stack: error?.stack ?? null,
+      },
+    })
+  }
+})

--- a/tests/unit/command-palette-utils.test.js
+++ b/tests/unit/command-palette-utils.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { highlightMatch, scoreCommands } from '../../src/client/components/commandPaletteUtils.js'
+
+describe('command palette utils', () => {
+  it('ranks commands by fuzzy score', () => {
+    const commands = [
+      { id: '1', title: 'Open Settings', description: 'Configure preferences', tags: ['settings'] },
+      { id: '2', title: 'Save World', description: 'Persist current changes' },
+      { id: '3', title: 'Spawn Companion', description: 'Summon a friendly unit', tags: ['spawn'] },
+    ]
+    const ranked = scoreCommands(commands, 'save')
+    expect(ranked.map(entry => entry.command.id)).toEqual(['2'])
+  })
+
+  it('splits highlight segments for matched text', () => {
+    const segments = highlightMatch('Save World', 'wo')
+    expect(segments).toHaveLength(3)
+    expect(segments[1].highlight).toBe(true)
+    expect(segments[1].text.toLowerCase()).toBe('wo')
+  })
+})

--- a/tests/unit/server-quests.test.js
+++ b/tests/unit/server-quests.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ServerQuests } from '../../src/core/systems/ServerQuests.js'
+
+function createWorld(overrides = {}) {
+  return {
+    tasks: overrides.tasks,
+  }
+}
+
+describe('ServerQuests', () => {
+  it('delegates progress simulation to the task queue when available', async () => {
+    const run = vi.fn().mockResolvedValue({
+      progress: {
+        'speak-to-guide': { count: 1, completed: true },
+      },
+      summary: { status: 'ready-to-turn-in' },
+    })
+    const quests = new ServerQuests(createWorld({ tasks: { run } }))
+    await quests.init()
+    const { state, summary } = await quests.enrichQuestState({ questId: 'welcome-to-hyperfy' }, {
+      events: [{ stepId: 'speak-to-guide', type: 'talk' }],
+    })
+    expect(run).toHaveBeenCalledWith('quest:simulate-progress', expect.objectContaining({
+      definition: expect.objectContaining({ id: 'welcome-to-hyperfy' }),
+    }))
+    expect(summary.status).toBe('ready-to-turn-in')
+    expect(state.progress['speak-to-guide'].completed).toBe(true)
+  })
+
+  it('falls back to inline handlers when no task queue is registered', async () => {
+    const quests = new ServerQuests(createWorld())
+    await quests.init()
+    const { state, summary } = await quests.enrichQuestState({ questId: 'welcome-to-hyperfy' }, {
+      events: [
+        { stepId: 'speak-to-guide', type: 'talk', amount: 1 },
+        { stepId: 'visit-builder', type: 'visit', amount: 1 },
+        { stepId: 'collect-resource', type: 'collect', amount: 3 },
+      ],
+    })
+    expect(summary.status).toBe('ready-to-turn-in')
+    expect(state.progress['collect-resource'].count).toBe(3)
+  })
+})

--- a/tests/unit/server-task-queue.test.js
+++ b/tests/unit/server-task-queue.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { TaskPool } from '../../src/server/runtime/TaskPool.js'
+
+const questDefinition = {
+  id: 'test',
+  steps: [
+    { id: 'collect', type: 'collect', count: 2 },
+    { id: 'defeat', type: 'defeat', count: 3 },
+  ],
+}
+
+describe('TaskPool', () => {
+  it('executes quest simulation tasks across workers', async () => {
+    const pool = new TaskPool({ size: 2 })
+    const events = [
+      { stepId: 'collect', type: 'collect', amount: 1 },
+      { stepId: 'collect', type: 'collect', amount: 1 },
+      { stepId: 'defeat', type: 'defeat', amount: 2 },
+      { stepId: 'defeat', type: 'defeat', amount: 1 },
+    ]
+    const [resultA, resultB] = await Promise.all([
+      pool.run('quest:simulate-progress', { definition: questDefinition, events }),
+      pool.run('metrics:aggregate-frames', {
+        frames: [
+          { durationMs: 3.2 },
+          { durationMs: 4.8 },
+        ],
+      }),
+    ])
+    expect(resultA.progress.collect.count).toBe(2)
+    expect(resultA.summary.status).toBe('ready-to-turn-in')
+    expect(resultB.maxDuration).toBeCloseTo(4.8, 5)
+    await pool.destroy()
+  })
+
+  it('falls back to inline execution when workers are unavailable', async () => {
+    const pool = new TaskPool({ size: 1 })
+    await pool.destroy()
+    const inlinePool = new TaskPool({ inlineFallback: true })
+    const result = await inlinePool.run('quest:simulate-progress', {
+      definition: questDefinition,
+      events: [{ stepId: 'collect', type: 'collect', amount: 5 }],
+    })
+    expect(result.progress.collect.count).toBe(2)
+    await inlinePool.destroy()
+  })
+})


### PR DESCRIPTION
## Summary
- introduce a worker-thread TaskPool with server quest orchestration and a reusable task queue system
- enhance the command palette with fuzzy ranking, keyboard navigation, and highlighting utilities
- add deployment preflight automation, documentation updates, and new unit coverage for quests and task execution

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_6900014ee814832da1ab3d48902c0002