### PR TITLE
feat: add secrets drift audit tooling

### DIFF
--- a/config/secrets/README.md
+++ b/config/secrets/README.md
@@ -1,0 +1,26 @@
+# Secrets Inventory
+
+The `inventory.yaml` file captures every managed secret that Hyperfy expects
+for each environment. The drift audit (`npm run ops:secrets`) compares the
+inventory against the environment overlays in `config/environments/*.yaml`
+to guarantee that:
+
+1. Each secret referenced by an overlay is documented with an owner,
+   description, and managed location.
+2. Every secret field in the inventory is actually consumed by the runtime so
+   unused credentials are flagged.
+3. Missing or renamed secrets are surfaced before rollout so operators can
+   remediate drift in the underlying secrets manager.
+
+The inventory intentionally omits the secret values. Instead, it records the
+provider (for example Doppler or AWS Secrets Manager), the secret identifier,
+and the expected fields. At deploy time, automation pulls the real values from
+the configured provider.
+
+When new secrets are introduced:
+
+- Update the relevant overlay in `config/environments/`.
+- Add the provider/identifier entry plus any required fields to
+  `inventory.yaml`.
+- Run `npm run ops:secrets` to confirm the overlays and inventory stay in
+  sync.

--- a/config/secrets/inventory.yaml
+++ b/config/secrets/inventory.yaml
@@ -1,0 +1,99 @@
+defaults:
+  owners:
+    - Platform Engineering
+  tags:
+    - runtime
+
+environments:
+  - name: development
+    description: Local developer footprint managed through Doppler projects.
+    secrets:
+      - provider: doppler
+        name: hyperfy/development/server
+        description: Fastify runtime credentials for local development.
+        fields:
+          - jwt_secret
+          - admin_code
+      - provider: doppler
+        name: hyperfy/development/livekit
+        description: LiveKit credentials for local ingest and publishing.
+        fields:
+          - api_key
+          - api_secret
+      - provider: doppler
+        name: hyperfy/development/database
+        description: Postgres connection string for local persistence.
+        fields:
+          - url
+      - provider: doppler
+        name: hyperfy/development/cdn
+        description: Asset bucket signing secret for local pushes.
+        fields:
+          - signing_key
+      - provider: doppler
+        name: hyperfy/development/sim
+        description: Cluster token for local simulation agents.
+        fields:
+          - cluster_token
+
+  - name: staging
+    description: Pre-production footprint mirroring production scale in AWS Secrets Manager.
+    secrets:
+      - provider: aws-secretsmanager
+        name: hyperfy/staging/server
+        description: Fastify runtime credentials for staging deployments.
+        fields:
+          - jwt_secret
+          - admin_code
+      - provider: aws-secretsmanager
+        name: hyperfy/staging/livekit
+        description: LiveKit credentials for staging ingest and publishing.
+        fields:
+          - api_key
+          - api_secret
+      - provider: aws-secretsmanager
+        name: hyperfy/staging/database
+        description: Staging database connection string managed by RDS.
+        fields:
+          - url
+      - provider: aws-secretsmanager
+        name: hyperfy/staging/cdn
+        description: CDN signing key for staging asset distribution.
+        fields:
+          - signing_key
+      - provider: aws-secretsmanager
+        name: hyperfy/staging/sim
+        description: Simulation cluster token for staging workloads.
+        fields:
+          - cluster_token
+
+  - name: production
+    description: Production footprint backed by AWS Secrets Manager.
+    secrets:
+      - provider: aws-secretsmanager
+        name: hyperfy/production/server
+        description: Fastify runtime credentials for the live service.
+        fields:
+          - jwt_secret
+          - admin_code
+      - provider: aws-secretsmanager
+        name: hyperfy/production/livekit
+        description: LiveKit credentials for production ingest and publishing.
+        fields:
+          - api_key
+          - api_secret
+      - provider: aws-secretsmanager
+        name: hyperfy/production/database
+        description: Production database connection string managed by RDS.
+        fields:
+          - url
+      - provider: aws-secretsmanager
+        name: hyperfy/production/cdn
+        description: CDN signing key for production asset distribution.
+        fields:
+          - signing_key
+      - provider: aws-secretsmanager
+        name: hyperfy/production/sim
+        description: Simulation cluster token for production workloads.
+        fields:
+          - cluster_token

--- a/docs/deployment/checklist.md
+++ b/docs/deployment/checklist.md
@@ -11,7 +11,7 @@ Status field during weekly ops reviews.
 | --- | --- | --- | --- | --- |
 | OPS-ENV-001 | Not Started | Provision environment variables via a managed secrets store (Vault, AWS Secrets Manager, Doppler). | GitHub issue `OPS-ENV-001` | Blocks automated rollouts; requires Terraform module ownership defined in [ops runbook](../runbooks/diagnostics-cli.md). |
 | OPS-ENV-002 | Not Started | Define per-environment configuration overlays (dev/staging/prod) with LiveKit URLs, database DSNs, CDN buckets, and signing keys. | GitHub issue `OPS-ENV-002` | Config bundles should align with IaC layouts captured in [`docs/roadmap/hardening-plan.md`](../roadmap/hardening-plan.md). |
-| OPS-ENV-003 | In Progress | Introduce automated drift detection for secrets (Terraform state or rotation alerts). | GitHub issue `OPS-ENV-003` | Preflight automation (`scripts/ops/preflight.mjs`) now validates required secrets before deployment; integrate with observability alerts next. |
+| OPS-ENV-003 | Complete | Introduce automated drift detection for secrets (Terraform state or rotation alerts). | GitHub issue `OPS-ENV-003` | Secrets drift audit landed in `scripts/ops/check-secrets-drift.mjs` (`npm run ops:secrets`); wire results into observability next. |
 
 ## Objective OPS-O2 — Infrastructure Automation
 
@@ -79,7 +79,7 @@ This checklist captures the minimum hardening required to move a Hyperfy self-ho
 - [x] Provision environment variables through a managed secrets store (Vault, AWS Secrets Manager, Doppler) rather than `.env` files committed to hosts. Refer to `config/environments/*.yaml`, the Terraform/Pulumi secret wiring, and the ExternalSecret/nomad templates for usage examples.
 - [x] Define per-environment configuration overlays (development, staging, production) describing LiveKit URLs, database DSNs, CDN buckets, and signing keys (`config/environments/`).
 - [x] Run the automated deployment preflight (`npm run ops:preflight`) to validate required secrets, world assets, and worker thread readiness before a rollout (`scripts/ops/preflight.mjs`).
-- [ ] Introduce automated drift detection for secrets (e.g., Terraform state or secrets rotation alerts).
+- [x] Introduce automated drift detection for secrets (e.g., Terraform state or secrets rotation alerts) via `npm run ops:secrets`.
 
 ## 2. Infrastructure Automation
 - [x] Codify Fastify/Node services, LiveKit, databases, and asset/CDN storage in infrastructure-as-code (Terraform or Pulumi) with reproducible environments (`infrastructure/terraform`, `infrastructure/pulumi`).

--- a/docs/deployment/preflight.md
+++ b/docs/deployment/preflight.md
@@ -33,5 +33,6 @@ pipeline should fail if any blocking failures are reported.
   migrations, CDN write access, or observability endpoints.
 - Export metrics from the preflight into your monitoring stack so repeated
   failures surface as alerts.
-- Pair the script with infrastructure drift detection (OPS-ENV-003) to close the
-  loop between pre-deployment validation and long-term secrets governance.
+- Pair the script with the automated secrets drift audit (`npm run ops:secrets`,
+  OPS-ENV-003) to close the loop between pre-deployment validation and long-term
+  secrets governance.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "node-client:build": "node scripts/build-node-client.mjs",
     "diagnostics": "node scripts/server-diagnostics.mjs",
     "ops:preflight": "node scripts/ops/preflight.mjs",
+    "ops:secrets": "node scripts/ops/check-secrets-drift.mjs",
     "lint": "eslint . --ext .js,.jsx",
     "lint:fix": "eslint . --ext .js,.jsx --fix",
     "format": "prettier --write .",

--- a/scripts/ops/check-secrets-drift.mjs
+++ b/scripts/ops/check-secrets-drift.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { executeCli } from './lib/secrets-drift.js'
+
+executeCli()

--- a/scripts/ops/lib/secrets-drift.js
+++ b/scripts/ops/lib/secrets-drift.js
@@ -1,0 +1,247 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import YAML from 'yaml'
+
+function resolveRepoRoot(fromPath = import.meta.url) {
+  const moduleDir = path.dirname(fileURLToPath(fromPath))
+  return path.resolve(moduleDir, '../../..')
+}
+
+function readYamlFile(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8')
+  return YAML.parse(raw) ?? {}
+}
+
+export function loadInventory(repoRoot = resolveRepoRoot(import.meta.url)) {
+  const inventoryPath = path.join(repoRoot, 'config', 'secrets', 'inventory.yaml')
+  if (!fs.existsSync(inventoryPath)) {
+    throw new Error(`Secrets inventory not found at ${inventoryPath}`)
+  }
+
+  const data = readYamlFile(inventoryPath)
+  const environments = new Map()
+
+  for (const entry of data.environments ?? []) {
+    const name = entry?.name ?? entry?.environment
+    if (!name) continue
+
+    const secrets = new Map()
+    for (const secret of entry.secrets ?? []) {
+      const provider = secret?.provider ?? entry?.provider ?? data?.defaults?.provider
+      const identifier = secret?.name ?? secret?.secret ?? secret?.id
+      if (!provider || !identifier) continue
+
+      const key = `${provider}/${identifier}`
+      const fields = new Set()
+      for (const field of secret.fields ?? []) {
+        if (field) fields.add(field)
+      }
+
+      secrets.set(key, {
+        provider,
+        identifier,
+        key,
+        optional: Boolean(secret?.optional ?? entry?.optional ?? false),
+        fields,
+        description: secret?.description ?? '',
+        owners: secret?.owners ?? entry?.owners ?? data?.defaults?.owners ?? [],
+        tags: secret?.tags ?? entry?.tags ?? data?.defaults?.tags ?? [],
+        used: false,
+        usedFields: new Set(),
+      })
+    }
+
+    environments.set(name, {
+      entry,
+      secrets,
+    })
+  }
+
+  return {
+    environments,
+    raw: data,
+  }
+}
+
+function normalizeOverlayEnvironment(fileName, overlay) {
+  if (overlay?.environment && typeof overlay.environment === 'string') {
+    return overlay.environment
+  }
+  return path.basename(fileName, path.extname(fileName))
+}
+
+export function loadOverlaySecrets(repoRoot = resolveRepoRoot(import.meta.url)) {
+  const overlaysDir = path.join(repoRoot, 'config', 'environments')
+  if (!fs.existsSync(overlaysDir)) {
+    throw new Error(`Environment overlays directory missing at ${overlaysDir}`)
+  }
+
+  const files = fs.readdirSync(overlaysDir).filter(name => name.endsWith('.yaml'))
+  const overlays = []
+
+  for (const fileName of files) {
+    const fullPath = path.join(overlaysDir, fileName)
+    const overlay = readYamlFile(fullPath)
+    const environment = normalizeOverlayEnvironment(fileName, overlay)
+
+    for (const entry of overlay?.variables ?? []) {
+      if (!entry || entry.source !== 'secret') continue
+      const provider = entry.provider ?? 'secret-manager'
+      const identifier = entry.secret ?? entry.path
+      const field = entry.field ?? null
+      if (!identifier) continue
+
+      overlays.push({
+        environment,
+        file: fullPath,
+        variable: entry.name,
+        provider,
+        identifier,
+        key: `${provider}/${identifier}`,
+        field,
+        description: entry.description ?? '',
+      })
+    }
+  }
+
+  return overlays
+}
+
+export function analyzeSecrets({ inventory, overlays }) {
+  const issues = []
+  const warnings = []
+  const stats = {
+    environments: new Set(),
+    overlays: overlays.length,
+    secretsReferenced: 0,
+    fieldsReferenced: 0,
+  }
+
+  for (const overlay of overlays) {
+    stats.environments.add(overlay.environment)
+    const envInventory = inventory.environments.get(overlay.environment)
+    if (!envInventory) {
+      issues.push({
+        level: 'error',
+        message: `Environment "${overlay.environment}" is missing from the secrets inventory`,
+        detail: `Variable ${overlay.variable} in ${overlay.file} references ${overlay.key}`,
+      })
+      continue
+    }
+
+    const secretRecord = envInventory.secrets.get(overlay.key)
+    if (!secretRecord) {
+      issues.push({
+        level: 'error',
+        message: `Secret ${overlay.key} is not documented for environment "${overlay.environment}"`,
+        detail: `Variable ${overlay.variable} in ${overlay.file} requires this secret`,
+      })
+      continue
+    }
+
+    secretRecord.used = true
+    stats.secretsReferenced += 1
+
+    if (overlay.field) {
+      if (!secretRecord.fields.has(overlay.field)) {
+        issues.push({
+          level: 'error',
+          message: `Field ${overlay.field} missing from secrets inventory for ${overlay.key}`,
+          detail: `Variable ${overlay.variable} in ${overlay.file}`,
+        })
+        continue
+      }
+
+      secretRecord.fields.delete(overlay.field)
+      secretRecord.usedFields.add(overlay.field)
+      stats.fieldsReferenced += 1
+    }
+  }
+
+  for (const [environment, envInventory] of inventory.environments) {
+    for (const secret of envInventory.secrets.values()) {
+      if (!secret.used) {
+        const level = secret.optional ? 'warn' : 'error'
+        const bucket = level === 'warn' ? warnings : issues
+        bucket.push({
+          level,
+          message: `Documented secret ${secret.key} for environment "${environment}" is not referenced by any overlay`,
+        })
+      }
+
+      if (secret.fields.size > 0) {
+        const level = secret.optional ? 'warn' : 'error'
+        const bucket = level === 'warn' ? warnings : issues
+        bucket.push({
+          level,
+          message: `Inventory fields ${Array.from(secret.fields).join(', ')} for ${secret.key} ` +
+            `(${environment}) are not used by overlays`,
+        })
+      }
+    }
+  }
+
+  return {
+    issues,
+    warnings,
+    stats: {
+      environmentsAudited: stats.environments.size,
+      overlaysAnalyzed: stats.overlays,
+      secretsReferenced: stats.secretsReferenced,
+      fieldsReferenced: stats.fieldsReferenced,
+    },
+  }
+}
+
+export function formatFindings({ issues, warnings, stats }) {
+  const lines = []
+  lines.push('🔐 Hyperfy secrets drift audit')
+  lines.push('--------------------------------')
+  lines.push(
+    `Environments: ${stats.environmentsAudited} | Secret refs: ${stats.secretsReferenced} | Field refs: ${stats.fieldsReferenced}`
+  )
+
+  if (issues.length === 0 && warnings.length === 0) {
+    lines.push('✅ No drift detected between overlays and the inventory.')
+  } else {
+    for (const issue of issues) {
+      lines.push(`❌ ${issue.message}` + (issue.detail ? ` — ${issue.detail}` : ''))
+    }
+    for (const warning of warnings) {
+      lines.push(`⚠️ ${warning.message}` + (warning.detail ? ` — ${warning.detail}` : ''))
+    }
+
+    if (issues.length === 0) {
+      lines.push(`⚠️ Audit completed with ${warnings.length} warning(s).`)
+    } else {
+      lines.push(`❌ Audit failed with ${issues.length} blocking issue(s) and ${warnings.length} warning(s).`)
+    }
+  }
+
+  return lines
+}
+
+export function runAudit({ inventoryRoot } = {}) {
+  const repoRoot = inventoryRoot ?? resolveRepoRoot(import.meta.url)
+  const inventory = loadInventory(repoRoot)
+  const overlays = loadOverlaySecrets(repoRoot)
+  return analyzeSecrets({ inventory, overlays })
+}
+
+export function executeCli() {
+  try {
+    const result = runAudit()
+    const output = formatFindings(result)
+    for (const line of output) {
+      console.log(line)
+    }
+    if (result.issues.length > 0) {
+      process.exitCode = 1
+    }
+  } catch (error) {
+    console.error('❌ Secrets drift audit failed:', error.message)
+    process.exitCode = 1
+  }
+}

--- a/tests/unit/secrets-drift.test.js
+++ b/tests/unit/secrets-drift.test.js
@@ -1,0 +1,41 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  analyzeSecrets,
+  loadInventory,
+  loadOverlaySecrets,
+} from '../../scripts/ops/lib/secrets-drift.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..', '..')
+
+describe('secrets drift audit', () => {
+  it('matches the documented inventory with environment overlays', () => {
+    const inventory = loadInventory(repoRoot)
+    const overlays = loadOverlaySecrets(repoRoot)
+    const result = analyzeSecrets({ inventory, overlays })
+
+    expect(result.issues).toHaveLength(0)
+    expect(result.warnings).toHaveLength(0)
+    expect(result.stats.environmentsAudited).toBeGreaterThan(0)
+    expect(result.stats.secretsReferenced).toBeGreaterThan(0)
+  })
+
+  it('flags overlays that reference undocumented secret fields', () => {
+    const inventory = loadInventory(repoRoot)
+    const overlays = loadOverlaySecrets(repoRoot).map((entry, index) => {
+      if (index === 0) {
+        return { ...entry, field: 'nonexistent_field' }
+      }
+      return entry
+    })
+
+    const result = analyzeSecrets({ inventory, overlays })
+
+    expect(result.issues.length).toBeGreaterThan(0)
+    expect(result.issues[0].message).toContain('Field nonexistent_field missing')
+  })
+})


### PR DESCRIPTION
## Summary
- document the managed secrets inventory and capture provider/field metadata per environment
- add a reusable secrets drift audit library plus a CLI entry point wired to `npm run ops:secrets`
- update deployment docs and tests to cover the new automation and mark OPS-ENV-003 complete

## Testing
- npm run test:unit
- npm run ops:secrets

------
https://chatgpt.com/codex/tasks/task_e_6900142327f8832db3b4e4e7569fb4f6