### PR TITLE
Add adaptive worker scaling to TaskPool

### DIFF
--- a/docs/runtime/task-pool.md
+++ b/docs/runtime/task-pool.md
@@ -1,0 +1,45 @@
+# Task Pool Runtime
+
+The task pool runs background jobs inside Node.js worker threads so the main simulation loop stays responsive. This document outlines the concurrency controls that back those workers and how to tune them for different workloads.
+
+## Default Behaviour
+
+The pool eagerly spins up a baseline set of workers on startup (defaulting to the previously fixed size of up to four CPUs) and dispatches registered tasks to those workers. If worker creation fails at boot time the pool drops into inline execution so the system continues to function.
+
+## Adaptive Scaling
+
+To better support bursty MMO workloads the pool can now scale beyond the baseline size. Provide a `maxSize` larger than the `minSize` (or legacy `size`) option and the pool will spawn extra workers whenever the queue depth per busy worker meets the `scaleThreshold` you set. Extra workers are reclaimed once they remain idle for longer than `idleTimeout`.
+
+```js
+import { TaskPool } from '#server/runtime/TaskPool.js'
+
+const pool = new TaskPool({
+  minSize: 2,
+  maxSize: 8,
+  scaleThreshold: 1.5,
+  idleTimeout: 15_000,
+})
+```
+
+The example above starts with two workers, grows up to eight during queue spikes, and retires surplus workers after 15 seconds of idleness. All configuration knobs are optional—omitting `maxSize` preserves the original fixed-size behaviour.
+
+## Diagnostics
+
+Call `pool.metrics()` to inspect the live state of the pool:
+
+| Field | Description |
+| --- | --- |
+| `workers` | Current worker count. |
+| `idleWorkers` | Workers waiting for jobs. |
+| `pendingJobs` | Jobs queued but not yet assigned. |
+| `inFlightJobs` | Jobs currently running in workers. |
+| `peakWorkers` | Maximum concurrent workers observed since creation. |
+| `inlineFallback` | `true` when the pool is executing tasks inline. |
+
+The new `diagnostics:delay` task handler offers a lightweight way to simulate work in development environments while validating scaling behaviour.
+
+## Operational Notes
+
+* Scaling is opt-in; keep the legacy `size` parameter for deterministic worker counts during soak testing.
+* Set `idleTimeout` to `0` to disable worker retirement when you want to pin the pool at peak capacity.
+* Inline fallback remains as before: if every worker crashes or the runtime cannot spawn worker threads, the pool keeps serving tasks synchronously so that critical pipelines do not stall.

--- a/src/server/runtime/TaskPool.js
+++ b/src/server/runtime/TaskPool.js
@@ -29,17 +29,29 @@ function formatWorkerError(error, taskName) {
 export class TaskPool {
   constructor(options = {}) {
     const cpuCount = os.cpus()?.length ?? 1
-    const desiredSize = options.size ?? Math.max(1, Math.min(cpuCount - 1, 4))
-    this.size = Math.max(1, desiredSize)
+    const defaultSize = Math.max(1, Math.min(cpuCount - 1, 4))
+    const requestedSize = Math.max(1, options.size ?? defaultSize)
+    const minSize = Math.max(1, options.minSize ?? requestedSize)
+    const computedMax = options.maxSize ?? (options.size != null || options.minSize != null ? minSize : minSize)
+
+    this.minSize = minSize
+    this.maxSize = Math.max(this.minSize, computedMax)
     this.inlineFallback = options.inlineFallback ?? false
+    this.scaleThreshold = Math.max(1, options.scaleThreshold ?? 2)
+    this.idleTimeout = options.idleTimeout === 0 ? 0 : Math.max(0, options.idleTimeout ?? 30_000)
+    this.autoScale = this.maxSize > this.minSize
     this.idle = []
     this.queue = []
     this.pending = new Map()
     this.workers = new Set()
     this.destroyed = false
+    this.idleTimers = new Map()
+    this.stats = {
+      peakWorkers: 0,
+    }
 
     if (!this.inlineFallback) {
-      for (let index = 0; index < this.size; index++) {
+      for (let index = 0; index < this.minSize; index++) {
         this.#spawnWorker()
       }
     }
@@ -66,6 +78,7 @@ export class TaskPool {
   async destroy() {
     this.destroyed = true
     for (const worker of this.workers) {
+      this.#clearIdleTimer(worker)
       worker.removeAllListeners()
       await worker.terminate()
     }
@@ -76,9 +89,16 @@ export class TaskPool {
     }
     this.pending.clear()
     this.queue.length = 0
+    for (const timer of this.idleTimers.values()) {
+      clearTimeout(timer)
+    }
+    this.idleTimers.clear()
   }
 
   #spawnWorker() {
+    if (this.workers.size >= this.maxSize) {
+      return
+    }
     try {
       const worker = createWorker()
       worker.on('message', message => {
@@ -94,6 +114,7 @@ export class TaskPool {
       })
       this.workers.add(worker)
       this.idle.push(worker)
+      this.stats.peakWorkers = Math.max(this.stats.peakWorkers, this.workers.size)
       this.#drain()
     } catch (error) {
       this.inlineFallback = true
@@ -103,17 +124,22 @@ export class TaskPool {
 
   #drain() {
     if (this.inlineFallback) return
+    this.#maybeScale()
     while (this.queue.length > 0 && this.idle.length > 0) {
       const job = this.queue.shift()
       const worker = this.idle.pop()
       if (!worker) break
       job.worker = worker
       this.pending.set(job.id, job)
+      this.#clearIdleTimer(worker)
       worker.postMessage({
         id: job.id,
         taskName: job.taskName,
         payload: job.payload,
       })
+    }
+    if (this.queue.length > 0) {
+      this.#maybeScale()
     }
   }
 
@@ -128,6 +154,7 @@ export class TaskPool {
     this.pending.delete(message.id)
     if (!this.destroyed) {
       this.idle.push(worker)
+      this.#scheduleIdleReclaim(worker)
     }
     if (message.error) {
       job.reject(formatWorkerError(message.error, job.taskName))
@@ -139,6 +166,7 @@ export class TaskPool {
 
   #handleWorkerFailure(worker, error) {
     if (this.destroyed) return
+    this.#clearIdleTimer(worker)
     for (const [id, job] of this.pending.entries()) {
       if (job.worker === worker) {
         this.pending.delete(id)
@@ -159,5 +187,93 @@ export class TaskPool {
       console.warn('[TaskPool] Worker failure:', error)
     }
     this.#drain()
+  }
+
+  #maybeScale() {
+    if (!this.autoScale || this.inlineFallback) {
+      return
+    }
+    if (this.workers.size >= this.maxSize) {
+      return
+    }
+    if (this.queue.length === 0) {
+      return
+    }
+    if (this.idle.length > 0) {
+      return
+    }
+    const busyWorkers = Math.max(1, this.workers.size - this.idle.length)
+    const saturation = this.queue.length / busyWorkers
+    if (saturation >= this.scaleThreshold) {
+      this.#spawnWorker()
+    }
+  }
+
+  #scheduleIdleReclaim(worker) {
+    if (!this.autoScale || this.idleTimeout <= 0) {
+      return
+    }
+    if (this.destroyed) {
+      return
+    }
+    if (this.workers.size <= this.minSize) {
+      return
+    }
+    if (this.idleTimers.has(worker)) {
+      return
+    }
+    const timer = setTimeout(() => {
+      this.idleTimers.delete(worker)
+      void this.#retireWorker(worker)
+    }, this.idleTimeout)
+    if (typeof timer.unref === 'function') {
+      timer.unref()
+    }
+    this.idleTimers.set(worker, timer)
+  }
+
+  #clearIdleTimer(worker) {
+    const timer = this.idleTimers.get(worker)
+    if (timer) {
+      clearTimeout(timer)
+      this.idleTimers.delete(worker)
+    }
+  }
+
+  async #retireWorker(worker) {
+    if (this.destroyed) {
+      return
+    }
+    if (this.workers.size <= this.minSize) {
+      return
+    }
+    if (!this.workers.has(worker)) {
+      return
+    }
+    this.workers.delete(worker)
+    const index = this.idle.indexOf(worker)
+    if (index >= 0) {
+      this.idle.splice(index, 1)
+    }
+    worker.removeAllListeners()
+    try {
+      await worker.terminate()
+    } catch (error) {
+      console.warn('[TaskPool] Failed to retire worker:', error)
+    }
+    if (this.workers.size === 0) {
+      this.inlineFallback = true
+    }
+  }
+
+  metrics() {
+    return {
+      workers: this.workers.size,
+      idleWorkers: this.idle.length,
+      pendingJobs: this.queue.length,
+      inFlightJobs: this.pending.size,
+      peakWorkers: this.stats.peakWorkers,
+      inlineFallback: this.inlineFallback,
+    }
   }
 }

--- a/src/server/runtime/task-handlers.js
+++ b/src/server/runtime/task-handlers.js
@@ -103,9 +103,20 @@ async function aggregateMetrics(payload = {}) {
   }
 }
 
+async function delayDiagnostics(payload = {}) {
+  const duration = Math.max(0, Number(payload.durationMs ?? payload.duration ?? 0))
+  if (duration > 0) {
+    await new Promise(resolve => setTimeout(resolve, duration))
+  }
+  return {
+    waitedMs: duration,
+  }
+}
+
 export const taskHandlers = new Map([
   ['quest:simulate-progress', simulateQuest],
   ['metrics:aggregate-frames', aggregateMetrics],
+  ['diagnostics:delay', delayDiagnostics],
 ])
 
 export function hasTaskHandler(name) {

--- a/tests/unit/server-task-queue.test.js
+++ b/tests/unit/server-task-queue.test.js
@@ -10,6 +10,8 @@ const questDefinition = {
   ],
 }
 
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
+
 describe('TaskPool', () => {
   it('executes quest simulation tasks across workers', async () => {
     const pool = new TaskPool({ size: 2 })
@@ -44,5 +46,27 @@ describe('TaskPool', () => {
     })
     expect(result.progress.collect.count).toBe(2)
     await inlinePool.destroy()
+  })
+
+  it('auto scales under sustained load and retires excess workers when idle', async () => {
+    const pool = new TaskPool({
+      minSize: 1,
+      maxSize: 3,
+      scaleThreshold: 1,
+      idleTimeout: 25,
+    })
+    const tasks = []
+    for (let index = 0; index < 6; index++) {
+      tasks.push(pool.run('diagnostics:delay', { durationMs: 30 }))
+    }
+    await Promise.all(tasks)
+    const peakAfterLoad = pool.metrics().peakWorkers
+    expect(peakAfterLoad).toBeGreaterThanOrEqual(2)
+    await wait(60)
+    const metrics = pool.metrics()
+    expect(metrics.workers).toBe(1)
+    expect(metrics.idleWorkers).toBeGreaterThanOrEqual(0)
+    expect(metrics.inlineFallback).toBe(false)
+    await pool.destroy()
   })
 })


### PR DESCRIPTION
## Summary
- add adaptive sizing, idle retirement, and metrics reporting to the TaskPool runtime
- expose a diagnostics delay handler to support load testing and document the new controls
- expand the TaskPool unit suite to cover autoscaling behaviour

## Testing
- npm test -- server-task-queue *(fails: server runtime integration hook timeout)*
- npx vitest run tests/unit/server-task-queue.test.js


------
https://chatgpt.com/codex/tasks/task_e_69018be49110832da128cce6acc23273