### PR TITLE
Improve server tick scheduling and zone catch-up controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - loader: opt-in instanced skinned mesh decoding guarded by `ENABLE_INSTANCED_SKINNING` for crowds authored with `EXT_mesh_gpu_instancing`【F:src/core/libs/gltfloader/GLTFLoader.js†L1700-L1823】【F:src/core/constants/featureFlags.js†L1-L18】
 
 ### Changed
+- core: server tick scheduler now compensates for drift with configurable catch-up
+  budgets per zone.【F:src/core/systems/Server.js†L1-L154】【F:src/server/config.js†L104-L150】
 
 ### Fixed
 - physics: release PhysX query buffers and refresh controller/collider filter data in place to prevent leaks during zone reloads and simplify collision debugging【F:src/core/systems/Physics.js†L300-L620】【F:src/core/nodes/Controller.js†L1-L213】【F:src/core/nodes/Collider.js†L1-L214】

--- a/docs/roadmap/system-roadmap.md
+++ b/docs/roadmap/system-roadmap.md
@@ -27,7 +27,8 @@ This roadmap captures the current maturity of Hyperfy subsystems, outstanding ri
    - Add startup health probes and server readiness checks.
    - Expand Vitest smoke tests to cover environment overlay loading failures.
 2. **Performance & Scalability (Q1-Q2)**
-   - Implement adaptive tick rate scheduling informed by server load metrics.
+  - Extend the adaptive tick scheduler with load-informed rate adjustments; backlog
+    guards now prevent runaway catch-up work.
    - Profile WebSocket throughput under 100 concurrent sessions.
    - Introduce caching for static asset manifests.
 3. **Developer Experience (Q2)**

--- a/docs/server-zones.md
+++ b/docs/server-zones.md
@@ -10,8 +10,10 @@ state per zone while continuing to share the existing asset and collection pipel
 Set the `WORLD_ZONES` environment variable alongside the existing `WORLD` setting when
 booting the server. The value accepts either a JSON array or a comma-separated list.
 Each zone definition must include a unique `id`; optional fields provide a user-facing
-`label`, a relative `dataDir` for persistence, and a `tickRate` override (updates per
-second) that controls both simulation and networking frequency for that zone.
+`label`, a relative `dataDir` for persistence, a `tickRate` override (updates per
+second) that controls both simulation and networking frequency for that zone, and a
+`maxCatchUpTicks` budget that limits how many delayed frames are replayed when the
+server loop falls behind (defaults to `5`).
 
 ```bash
 # minimal comma-separated example
@@ -24,7 +26,7 @@ node src/server/index.js
 # JSON configuration with custom persistence folders and tick rates
 WORLD=my-world \
 WORLD_ZONES='[
-  {"id": "lobby", "label": "Public Lobby", "tickRate": 12},
+  {"id": "lobby", "label": "Public Lobby", "tickRate": 12, "maxCatchUpTicks": 4},
   {"id": "raid", "label": "Raid Instance", "dataDir": "zones/raid", "tickRate": 20}
 ]' \
 node src/server/index.js
@@ -50,8 +52,9 @@ player state:
 - `SERVER_NETWORK_THROTTLE_MS` enforces the minimum interval between updates about the
   same player to the same socket, preventing redundant packets (default: `50`).
 
-These knobs combine with each zone's `tickRate` to let operators balance simulation
-fidelity against bandwidth usage as populations grow.
+These knobs combine with each zone's `tickRate` and `maxCatchUpTicks` budget to let
+operators balance simulation fidelity against bandwidth usage as populations grow
+without letting backlog processing starve the current frame.
 
 ## Runtime Behaviour
 

--- a/src/core/systems/Server.js
+++ b/src/core/systems/Server.js
@@ -1,6 +1,7 @@
 import { System } from './System'
 
 const DEFAULT_TICKS_PER_SECOND = 30
+const DEFAULT_MAX_CATCH_UP_TICKS = 5
 
 /**
  * Server System
@@ -10,33 +11,88 @@ const DEFAULT_TICKS_PER_SECOND = 30
  *
  */
 export class Server extends System {
-  constructor(world) {
+  constructor(world, options = {}) {
     super(world)
     this.timerId = null
+    this.running = false
     this.tickInterval = 1 / DEFAULT_TICKS_PER_SECOND
+    this.tickIntervalMs = this.tickInterval * 1000
+    this.lastTickAt = 0
+    this.nextTickAt = 0
+    this.maxCatchUpTicks = Number.isInteger(options.maxCatchUpTicks) && options.maxCatchUpTicks >= 0
+      ? options.maxCatchUpTicks
+      : DEFAULT_MAX_CATCH_UP_TICKS
+    this.timeProvider = typeof options.timeProvider === 'function' ? options.timeProvider : () => performance.now()
   }
 
   start() {
+    if (this.running) return
+    this.running = true
     this.updateTickInterval()
+    const now = this.getTime()
+    this.lastTickAt = now - this.tickIntervalMs
+    this.nextTickAt = now
     this.tick()
   }
 
+  getTime() {
+    return this.timeProvider()
+  }
+
   tick = () => {
-    const time = performance.now()
-    this.world.tick(time)
+    if (!this.running) {
+      return
+    }
+
     this.updateTickInterval()
-    this.timerId = setTimeout(this.tick, this.tickInterval * 1000)
+
+    const now = this.getTime()
+    const maxCatchUpTicks = this.resolveMaxCatchUpTicks()
+
+    let executed = 0
+    let nextTarget = Number.isFinite(this.nextTickAt) && this.nextTickAt > 0 ? this.nextTickAt : now
+
+    while (now >= nextTarget && executed < maxCatchUpTicks) {
+      this.runTick(nextTarget)
+      executed += 1
+      nextTarget = this.lastTickAt + this.tickIntervalMs
+    }
+
+    if (executed === 0) {
+      const scheduledTime = Math.max(now, this.lastTickAt + this.tickIntervalMs)
+      this.runTick(scheduledTime)
+      nextTarget = this.lastTickAt + this.tickIntervalMs
+    } else if (executed >= maxCatchUpTicks && now >= nextTarget) {
+      nextTarget = now + this.tickIntervalMs
+      this.lastTickAt = now
+    }
+
+    this.nextTickAt = nextTarget
+
+    const delay = Math.max(0, this.nextTickAt - this.getTime())
+    this.timerId = setTimeout(this.tick, delay)
+  }
+
+  runTick(time) {
+    this.world.tick(time)
+    this.lastTickAt = time
+    this.updateTickInterval()
   }
 
   destroy() {
-    clearTimeout(this.timerId)
+    this.running = false
+    if (this.timerId) {
+      clearTimeout(this.timerId)
+      this.timerId = null
+    }
   }
 
   updateTickInterval() {
     const ticksPerSecond = this.resolveTickRate()
-    const interval = 1 / ticksPerSecond
-    if (interval !== this.tickInterval) {
-      this.tickInterval = interval
+    const intervalSeconds = 1 / ticksPerSecond
+    if (Number.isFinite(intervalSeconds) && intervalSeconds > 0) {
+      this.tickInterval = intervalSeconds
+      this.tickIntervalMs = intervalSeconds * 1000
     }
   }
 
@@ -46,5 +102,13 @@ export class Server extends System {
       return configured
     }
     return DEFAULT_TICKS_PER_SECOND
+  }
+
+  resolveMaxCatchUpTicks() {
+    const configured = this.world?.serverMaxCatchUpTicks
+    if (Number.isInteger(configured) && configured >= 0) {
+      return configured
+    }
+    return this.maxCatchUpTicks
   }
 }

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -152,6 +152,7 @@ function parseZoneConfig(rawValue, worldDir) {
     const dataDir = path.join(worldDir, relativeDataDir)
 
     let tickRate = null
+    let maxCatchUpTicks = null
     if (zone.tickRate !== undefined && zone.tickRate !== null && zone.tickRate !== '') {
       const numeric = Number(zone.tickRate)
       if (!Number.isFinite(numeric) || numeric <= 0) {
@@ -160,12 +161,25 @@ function parseZoneConfig(rawValue, worldDir) {
       tickRate = numeric
     }
 
+    if (
+      zone.maxCatchUpTicks !== undefined &&
+      zone.maxCatchUpTicks !== null &&
+      zone.maxCatchUpTicks !== ''
+    ) {
+      const numeric = Number(zone.maxCatchUpTicks)
+      if (!Number.isFinite(numeric) || numeric < 0) {
+        throw new Error(`WORLD_ZONES[${index}].maxCatchUpTicks must be zero or a positive number if provided`)
+      }
+      maxCatchUpTicks = Math.floor(numeric)
+    }
+
     zones.push(
       Object.freeze({
         id,
         label,
         dataDir,
         tickRate,
+        maxCatchUpTicks,
       })
     )
   }

--- a/src/server/runtime/createServerApp.js
+++ b/src/server/runtime/createServerApp.js
@@ -89,6 +89,9 @@ export async function createServerApp({
       world.networkRate = 1 / zoneConfig.tickRate
       world.serverTickRate = zoneConfig.tickRate
     }
+    if (Number.isInteger(zoneConfig.maxCatchUpTicks) && zoneConfig.maxCatchUpTicks >= 0) {
+      world.serverMaxCatchUpTicks = zoneConfig.maxCatchUpTicks
+    }
     world.assetsUrl = publicConfig.assetsUrl
     world.collections.deserialize(cloneCollections(baseCollections))
     await world.init({ db, storage, assetsDir })

--- a/tests/unit/server-config.test.js
+++ b/tests/unit/server-config.test.js
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function setBaseEnv() {
+  process.env.WORLD = 'world'
+  process.env.JWT_SECRET = 'secret'
+  for (const key of ['PUBLIC_ASSETS_URL', 'PUBLIC_API_URL', 'PUBLIC_WS_URL']) {
+    delete process.env[key]
+  }
+  delete process.env.WORLD_ZONES
+}
+
+describe('server config zone parsing', () => {
+  const ORIGINAL_ENV = { ...process.env }
+
+  beforeEach(() => {
+    vi.resetModules()
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key]
+    }
+    for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+      if (value !== undefined) {
+        process.env[key] = value
+      }
+    }
+    setBaseEnv()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key]
+    }
+    for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+      if (value !== undefined) {
+        process.env[key] = value
+      }
+    }
+  })
+
+  it('honours maxCatchUpTicks in WORLD_ZONES definitions', async () => {
+    process.env.WORLD_ZONES = JSON.stringify([
+      { id: 'alpha', tickRate: 20, maxCatchUpTicks: 3 },
+      { id: 'beta', maxCatchUpTicks: 0 },
+    ])
+
+    const { createServerConfig } = await import('../../src/server/config.js')
+    const config = createServerConfig({ rootDir: process.cwd() })
+
+    expect(config.server.zones[0].maxCatchUpTicks).toBe(3)
+    expect(config.server.zones[1].maxCatchUpTicks).toBe(0)
+  })
+
+  it('rejects negative maxCatchUpTicks values', async () => {
+    process.env.WORLD_ZONES = JSON.stringify([{ id: 'gamma', maxCatchUpTicks: -1 }])
+
+    await expect(async () => {
+      const { createServerConfig } = await import('../../src/server/config.js')
+      createServerConfig({ rootDir: process.cwd() })
+    }).rejects.toThrow(/maxCatchUpTicks/)
+  })
+})

--- a/tests/unit/server-scheduler.test.js
+++ b/tests/unit/server-scheduler.test.js
@@ -1,0 +1,93 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('Server scheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('limits catch-up ticks when the loop falls behind', async () => {
+    const { Server } = await import('../../src/core/systems/Server.js')
+    const tick = vi.fn()
+    let now = 0
+    const server = new Server({ tick }, { timeProvider: () => now, maxCatchUpTicks: 2 })
+
+    server.start()
+
+    expect(tick).toHaveBeenCalledTimes(1)
+
+    const intervalMs = server.tickInterval * 1000
+
+    now += intervalMs * 10
+    vi.advanceTimersToNextTimer()
+
+    expect(tick).toHaveBeenCalledTimes(1 + 2)
+
+    now += intervalMs
+    vi.advanceTimersToNextTimer()
+
+    expect(tick).toHaveBeenCalledTimes(1 + 2 + 1)
+
+    server.destroy()
+  })
+
+  it('prefers world-configured catch-up limits over constructor options', async () => {
+    const { Server } = await import('../../src/core/systems/Server.js')
+    const tick = vi.fn()
+    let now = 0
+    const world = { tick, serverMaxCatchUpTicks: 1 }
+    const server = new Server(world, { timeProvider: () => now, maxCatchUpTicks: 4 })
+
+    server.start()
+
+    expect(tick).toHaveBeenCalledTimes(1)
+
+    const intervalMs = server.tickInterval * 1000
+    now += intervalMs * 10
+    vi.advanceTimersToNextTimer()
+
+    expect(tick).toHaveBeenCalledTimes(1 + 1)
+
+    server.destroy()
+
+    now += intervalMs * 5
+    vi.advanceTimersByTime(intervalMs * 5)
+
+    expect(tick).toHaveBeenCalledTimes(1 + 1)
+  })
+
+  it('re-schedules ticks when the world changes the configured rate', async () => {
+    const { Server } = await import('../../src/core/systems/Server.js')
+    let now = 0
+    const world = {
+      serverTickRate: 30,
+      tick: vi.fn(time => {
+        if (time === 0) {
+          world.serverTickRate = 60
+        }
+      }),
+    }
+
+    const server = new Server(world, { timeProvider: () => now })
+
+    expect(server.tickInterval).toBeCloseTo(1 / 30, 5)
+
+    server.start()
+
+    const nextIntervalMs = server.tickInterval * 1000
+    expect(server.tickInterval).toBeCloseTo(1 / 60, 5)
+
+    now += nextIntervalMs
+    vi.advanceTimersToNextTimer()
+
+    expect(server.tickInterval).toBeCloseTo(1 / 60, 5)
+    expect(world.tick).toHaveBeenCalledTimes(2)
+    const secondTickTime = world.tick.mock.calls[1][0]
+    expect(secondTickTime).toBeCloseTo(nextIntervalMs, 5)
+
+    server.destroy()
+  })
+})


### PR DESCRIPTION
## Summary
- add an adaptive server scheduler that compensates for drift and bounds catch-up work
- allow zone configuration to set a maxCatchUpTicks budget and document the new control
- cover the scheduler and configuration parsing with targeted unit tests

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_690525712460832dbda9e7c981645122