### PR TITLE
feat: allow server constructor tick rate overrides

### DIFF
--- a/docs/server-zones.md
+++ b/docs/server-zones.md
@@ -56,6 +56,15 @@ These knobs combine with each zone's `tickRate` and `maxCatchUpTicks` budget to 
 operators balance simulation fidelity against bandwidth usage as populations grow
 without letting backlog processing starve the current frame.
 
+### Programmatic overrides
+
+When embedding the server runtime for tooling or testing, you can instantiate the
+`Server` system directly and pass constructor options to tune the scheduler without
+environment variables. For example, `new Server(world, { tickRate: 20, maxCatchUpTicks: 2 })`
+keeps the simulation locked to 20 Hz unless a specific world overrides
+`world.serverTickRate` at runtime. This mirrors the per-zone configuration while
+keeping ad-hoc harnesses deterministic.
+
 ## Runtime Behaviour
 
 - Each zone receives a dedicated SQLite database and storage file inside its configured

--- a/src/core/systems/Server.js
+++ b/src/core/systems/Server.js
@@ -22,7 +22,12 @@ export class Server extends System {
     this.maxCatchUpTicks = Number.isInteger(options.maxCatchUpTicks) && options.maxCatchUpTicks >= 0
       ? options.maxCatchUpTicks
       : DEFAULT_MAX_CATCH_UP_TICKS
+    this.configuredTickRate =
+      typeof options.tickRate === 'number' && Number.isFinite(options.tickRate) && options.tickRate > 0
+        ? options.tickRate
+        : null
     this.timeProvider = typeof options.timeProvider === 'function' ? options.timeProvider : () => performance.now()
+    this.updateTickInterval()
   }
 
   start() {
@@ -100,6 +105,9 @@ export class Server extends System {
     const configured = this.world?.serverTickRate
     if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
       return configured
+    }
+    if (typeof this.configuredTickRate === 'number' && Number.isFinite(this.configuredTickRate) && this.configuredTickRate > 0) {
+      return this.configuredTickRate
     }
     return DEFAULT_TICKS_PER_SECOND
   }

--- a/tests/unit/server-scheduler.test.js
+++ b/tests/unit/server-scheduler.test.js
@@ -59,6 +59,28 @@ describe('Server scheduler', () => {
     expect(tick).toHaveBeenCalledTimes(1 + 1)
   })
 
+  it('accepts constructor tick rates when the world does not provide one', async () => {
+    const { Server } = await import('../../src/core/systems/Server.js')
+    const tick = vi.fn()
+    let now = 0
+    const server = new Server({ tick }, { timeProvider: () => now, tickRate: 10 })
+
+    expect(server.tickInterval).toBeCloseTo(1 / 10, 5)
+
+    server.start()
+
+    expect(server.tickInterval).toBeCloseTo(1 / 10, 5)
+    expect(tick).toHaveBeenCalledTimes(1)
+
+    const intervalMs = server.tickInterval * 1000
+    now += intervalMs
+    vi.advanceTimersToNextTimer()
+
+    expect(tick).toHaveBeenCalledTimes(2)
+
+    server.destroy()
+  })
+
   it('re-schedules ticks when the world changes the configured rate', async () => {
     const { Server } = await import('../../src/core/systems/Server.js')
     let now = 0


### PR DESCRIPTION
## Summary
- allow specifying a tick rate via the Server constructor while continuing to defer to world-level overrides
- extend the scheduler unit suite to validate constructor tick rate handling
- document programmatic scheduler overrides for embedded tooling and tests

## Testing
- npx vitest run --config vitest.config.mjs tests/unit/server-scheduler.test.js

------
https://chatgpt.com/codex/tasks/task_e_690619878b60832daa77d7aee3eb62c5