### PR TITLE
Add terraform validation workflow

### DIFF
--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -1,0 +1,51 @@
+name: Terraform
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Fmt and validate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infrastructure/terraform
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.8.6
+
+      - name: Format check
+        run: terraform fmt -check -recursive
+
+      - name: Initialize (no backend)
+        run: terraform init -backend=false
+
+      - name: Validate configuration
+        run: >-
+          terraform validate -no-color
+          -var aws_region=us-east-1
+          -var project=hyperfy-ci
+          -var domain=example.com
+          -var api_certificate_arn=arn:aws:acm:us-east-1:111111111111:certificate/api
+          -var livekit_certificate_arn=arn:aws:acm:us-east-1:111111111111:certificate/livekit
+          -var sim_certificate_arn=arn:aws:acm:us-east-1:111111111111:certificate/sim
+          -var cdn_certificate_arn=arn:aws:acm:us-east-1:111111111111:certificate/cdn
+          -var fastify_image=ghcr.io/hyperfy-xyz/api:ci
+          -var fastify_desired_count=1
+          -var livekit_image=ghcr.io/hyperfy-xyz/livekit:ci
+          -var livekit_desired_count=1
+          -var sim_image=ghcr.io/hyperfy-xyz/sim:ci
+          -var sim_desired_count=1

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -47,3 +47,11 @@ After apply succeeds you will receive:
 
 Use the exported outputs to wire secrets into the Kubernetes/Nomad manifests or the
 GitHub Actions deployment workflows.
+
+## Continuous validation
+
+A GitHub Actions workflow (`.github/workflows/terraform-checks.yml`) keeps the stack
+fmt/validate clean on every push and PR. It runs `terraform fmt -check` and
+`terraform validate` with representative placeholder variables and without a
+remote backend to avoid credential requirements. Update the injected variables if
+new required inputs are added to the stack.


### PR DESCRIPTION
## Summary
- add a Terraform GitHub Actions workflow to format-check and validate the infrastructure stack without backend dependencies
- document the continuous validation workflow in the Terraform README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234e48d21c832db63fe2bae7b5d812)